### PR TITLE
Raise ArgumentError if client uses preview without proper configuration

### DIFF
--- a/lib/wcc/contentful/model_builder.rb
+++ b/lib/wcc/contentful/model_builder.rb
@@ -59,6 +59,10 @@ module WCC::Contentful
 
             result =
               if defined?(context[:preview]) && context[:preview] == true
+                if WCC::Contentful::Model.preview_store.nil?
+                  raise ArgumentError,
+                    'You must include a contentful preview token in your WCC::Contentful.configure block'
+                end
                 WCC::Contentful::Model.preview_store.find_by(content_type: content_type, filter: filter)
               else
                 WCC::Contentful::Model.store.find_by(content_type: content_type, filter: filter)


### PR DESCRIPTION
Right now, if a user makes a 'find_by' call to the preview api using the gem without having first configured the gem with a contentful preview token, you'll get a 500 NoMethodError that says you can't use find_by on Nil. This PR just raises an error for that scenario that explains the situation a little more clear.