### PR TITLE
Add option to ignore circular references

### DIFF
--- a/lib/wcc/contentful/exceptions.rb
+++ b/lib/wcc/contentful/exceptions.rb
@@ -45,6 +45,21 @@ module WCC::Contentful
   # Raised when an entry contains a circular reference and cannot be represented
   # as a flat tree.
   class CircularReferenceError < StandardError
+    attr_reader :stack
+    attr_reader :id
+
+    def initialize(stack, id)
+      @id = id
+      @stack = stack.slice(stack.index(id)..stack.length)
+      super('Circular reference detected!')
+    end
+
+    def message
+      return super unless stack
+      super + "\n  " \
+        "#{stack.last} points to #{id} which is also it's ancestor\n  " +
+        stack.join('->')
+    end
   end
 
   # Raised by {WCC::Contentful::ModelMethods#resolve Model#resolve} when attempting

--- a/lib/wcc/contentful/model_methods.rb
+++ b/lib/wcc/contentful/model_methods.rb
@@ -17,6 +17,11 @@ module WCC::Contentful::ModelMethods
   # @param [Hash] context passed to the resolved model's `new` function to provide
   #   contextual information ex. current locale.
   #   See {WCC::Contentful::ModelSingletonMethods#find Model#find}, {WCC::Contentful::Sys#context}
+  # @param [Hash] options The remaining optional parameters, defined below
+  # @option options [Symbol] circular_reference Determines how circular references are
+  #   handled.  `:raise` causes a {WCC::Contentful::CircularReferenceError} to be raised,
+  #   `:ignore` will cause the field to remain unresolved, and any other value (or nil)
+  #   will cause the field to point to the previously resolved ruby object for that ID.
   def resolve(depth: 1, fields: nil, context: {}, **options)
     raise ArgumentError, "Depth must be > 0 (was #{depth})" unless depth && depth > 0
     return self if resolved?(depth: depth, fields: fields)

--- a/lib/wcc/contentful/model_methods.rb
+++ b/lib/wcc/contentful/model_methods.rb
@@ -135,8 +135,8 @@ module WCC::Contentful::ModelMethods
       val = _try_map(val) { |v| load.call(v) if v }
 
       instance_variable_set(var_name + '_resolved', val)
-    rescue WCC::Contentful::CircularReferenceError => e
-      raise e unless options[:circular_reference] == :ignore
+    rescue WCC::Contentful::CircularReferenceError
+      raise unless options[:circular_reference] == :ignore
     end
   end
 


### PR DESCRIPTION
Model#resolve now accepts additional options to determine how to handle circular references.

Valid values are `:raise` and `:ignore`.  On a circular reference, the former will raise an error while the latter will leave the link un-resolved.