### PR TITLE
fix for .first method on postgress store resulting in invalid tuple number 0

### DIFF
--- a/lib/wcc/contentful/store/postgres_store.rb
+++ b/lib/wcc/contentful/store/postgres_store.rb
@@ -88,7 +88,7 @@ module WCC::Contentful::Store
         return @first if @first
         statement = 'SELECT * FROM contentful_raw ' + @statement + ' LIMIT 1'
         result = @conn.exec(statement, @params)
-        return if result.num_tuples.zero?
+        return if result.num_tuples == 0
         resolve_includes(
           JSON.parse(result.getvalue(0, 1)),
           @options[:include]

--- a/lib/wcc/contentful/store/postgres_store.rb
+++ b/lib/wcc/contentful/store/postgres_store.rb
@@ -88,6 +88,7 @@ module WCC::Contentful::Store
         return @first if @first
         statement = 'SELECT * FROM contentful_raw ' + @statement + ' LIMIT 1'
         result = @conn.exec(statement, @params)
+        return if result.num_tuples.zero?
         resolve_includes(
           JSON.parse(result.getvalue(0, 1)),
           @options[:include]

--- a/spec/support/store_examples.rb
+++ b/spec/support/store_examples.rb
@@ -350,6 +350,27 @@ RSpec.shared_examples 'contentful store' do
       expect(%w[k2 k6 k10]).to include(found.dig('sys', 'id'))
     end
 
+    it 'returns nil when cant find content type' do
+      content_types = %w[test1]
+      data =
+        1.upto(4).map do |i|
+          {
+            'sys' => {
+              'id' => "k#{i}",
+              'contentType' => { 'sys' => { 'id' => content_types[i % content_types.length] } }
+            },
+            'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+          }
+        end
+      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+      # act
+      nonexistent_content_type = subject.find_by(content_type: 'test2')
+
+      # assert
+      expect(nonexistent_content_type).to be nil
+    end
+
     it 'can apply filter object' do
       data =
         1.upto(10).map do |i|


### PR DESCRIPTION
When using the Postgres data store, calling `find_by(some_field: "some-field-that-does-not-exist")` results in an `<ArgumentError: invalid tuple number 0>` due to the `.first` method not returning in time if `result.num_tuples.zero?` as it is designed in the other methods such as `find`, `delete`, `set`