### PR TITLE
Fix Syntax Issue where Postgress requires parameters listed in function name, effects only pre version 10

### DIFF
--- a/lib/wcc/contentful/store/postgres_store.rb
+++ b/lib/wcc/contentful/store/postgres_store.rb
@@ -145,7 +145,7 @@ module WCC::Contentful::Store
         CREATE INDEX IF NOT EXISTS contentful_raw_value_type ON contentful_raw ((data->'sys'->>'type'));
         CREATE INDEX IF NOT EXISTS contentful_raw_value_content_type ON contentful_raw ((data->'sys'->'contentType'->'sys'->>'id'));
 
-        DROP FUNCTION IF EXISTS "upsert_entry";
+        DROP FUNCTION IF EXISTS "upsert_entry"(_id varchar, _data jsonb);
         CREATE FUNCTION "upsert_entry"(_id varchar, _data jsonb) RETURNS jsonb AS $$
         DECLARE
           prev jsonb;


### PR DESCRIPTION
I am running into issues when running my specs on SemaphoreCI.

There supported version of Postgres is 9.6.6.

According to this [Stackoverflow post](https://stackoverflow.com/questions/30782925/postgresql-how-to-drop-function-if-exists-without-specifying-parameters), Postgres 10 does not require the parameters listed when trying to drop a function. 

However, for the sake of compatibility, I would like to add the parameters to the drop function.

