### PR TITLE
Pass arguments correctly to DelayedSyncJob in sync_later!

### DIFF
--- a/app/jobs/wcc/contentful/delayed_sync_job.rb
+++ b/app/jobs/wcc/contentful/delayed_sync_job.rb
@@ -57,7 +57,7 @@ module WCC::Contentful
     # of time.
     def sync_later!(up_to_id: nil, wait: 10.minutes)
       WCC::Contentful::DelayedSyncJob.set(wait: wait)
-        .perform_later(up_to_id)
+        .perform_later(up_to_id: up_to_id)
     end
   end
 end

--- a/spec/jobs/wcc/contentful/delayed_sync_job_spec.rb
+++ b/spec/jobs/wcc/contentful/delayed_sync_job_spec.rb
@@ -128,4 +128,19 @@ RSpec.describe WCC::Contentful::DelayedSyncJob, type: :job do
       })
     end
   end
+
+  describe 'sync_later!' do
+    it 'drops another job with the given ID in 10 minutes' do
+      configured_job = double
+
+      expect(described_class).to receive(:set)
+        .with(wait: 10.minutes)
+        .and_return(configured_job)
+      expect(configured_job).to receive(:perform_later)
+        .with(up_to_id: 'foobar')
+
+      # act
+      job.sync_later!(up_to_id: 'foobar')
+    end
+  end
 end


### PR DESCRIPTION
In `DelayedSyncJob#sync_later!`, the String `up_to_id` is being passed to the job instead of a Hash.

Included a failing spec.