### PR TITLE
Wmresources 465 fix to h

### DIFF
--- a/lib/wcc/contentful/model_builder.rb
+++ b/lib/wcc/contentful/model_builder.rb
@@ -113,8 +113,14 @@ module WCC::Contentful
               end
 
               id_method_name = "#{name}_id"
-              define_method(id_method_name) do
-                instance_variable_get(var_name)&.dig('sys', 'id')
+              if f.array
+                define_method(id_method_name) do
+                  instance_variable_get(var_name)&.map { |link| link.dig('sys', 'id') }
+                end
+              else
+                define_method(id_method_name) do
+                  instance_variable_get(var_name)&.dig('sys', 'id')
+                end
               end
               alias_method id_method_name.underscore, id_method_name
             when :Coordinates

--- a/lib/wcc/contentful/model_builder.rb
+++ b/lib/wcc/contentful/model_builder.rb
@@ -114,6 +114,7 @@ module WCC::Contentful
 
               id_method_name = "#{name}_id"
               if f.array
+                id_method_name = "#{name}_ids"
                 define_method(id_method_name) do
                   instance_variable_get(var_name)&.map { |link| link.dig('sys', 'id') }
                 end

--- a/spec/wcc/contentful/model_builder_spec.rb
+++ b/spec/wcc/contentful/model_builder_spec.rb
@@ -253,7 +253,23 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
 
     # assert
+    expect(store).to_not receive(:find)
     expect(main_menu.hamburger_id).to eq('6y9DftpiYoA4YiKg2CgoUU')
+  end
+
+  it 'makes all IDs of a linked array accessible' do
+    @schema = subject.build_models
+
+    # act
+    side_menu = WCC::Contentful::Model::Menu.find('6y9DftpiYoA4YiKg2CgoUU')
+
+    # assert
+    expect(store).to_not receive(:find)
+    expect(side_menu.items_id).to eq(%w[
+                                       1IJEXB4AKEqQYEm4WuceG2
+                                       5NBhDw3i2kUqSwqYok4YQO
+                                       4tMhra8IAwcEoKS6QSQYcc
+                                     ])
   end
 
   it 'stores backreference on linked type context' do

--- a/spec/wcc/contentful/model_builder_spec.rb
+++ b/spec/wcc/contentful/model_builder_spec.rb
@@ -265,11 +265,13 @@ RSpec.describe WCC::Contentful::ModelBuilder do
 
     # assert
     expect(store).to_not receive(:find)
-    expect(side_menu.items_id).to eq(%w[
-                                       1IJEXB4AKEqQYEm4WuceG2
-                                       5NBhDw3i2kUqSwqYok4YQO
-                                       4tMhra8IAwcEoKS6QSQYcc
-                                     ])
+    expect(side_menu.items_ids).to eq(
+      %w[
+        1IJEXB4AKEqQYEm4WuceG2
+        5NBhDw3i2kUqSwqYok4YQO
+        4tMhra8IAwcEoKS6QSQYcc
+      ]
+    )
   end
 
   it 'stores backreference on linked type context' do

--- a/spec/wcc/contentful/model_methods_spec.rb
+++ b/spec/wcc/contentful/model_methods_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe WCC::Contentful::ModelMethods do
             {
               'sys' => {
                 'type' => 'Link',
-                'linkType' => 'Asset',
+                'linkType' => 'Entry',
                 'id' => '4'
               }
             }
@@ -701,7 +701,7 @@ RSpec.describe WCC::Contentful::ModelMethods do
           {
             'sys' => {
               'type' => 'Link',
-              'linkType' => 'Asset',
+              'linkType' => 'Entry',
               'id' => '4'
             }
           }
@@ -791,6 +791,23 @@ RSpec.describe WCC::Contentful::ModelMethods do
 
       round_trip = JSON.parse(h.to_json)
       expect(h).to eql(round_trip)
+    end
+
+    it 'calls into the defined methods on the subclass to get data' do
+      TO_H_TEST_1 =
+        Class.new(WCC::Contentful::Model::ToJsonTest) do
+          def name
+            'to-h-test-1:' + super
+          end
+        end
+
+      subject = TO_H_TEST_1.new(raw)
+
+      # act
+      h = subject.to_h
+
+      # assert
+      expect(h.dig('fields', 'name')).to eq('to-h-test-1:asdf')
     end
   end
 


### PR DESCRIPTION
* `to_h` now invokes the defined attribute readers on the model class in order to get fields.
* `to_h` no longer includes raw data deeper than the currently resolved depth on the model. 

refs https://github.com/watermarkchurch/watermarkresources.com/issues/465