### PR TITLE
94 import contentful helpers

### DIFF
--- a/wcc-contentful/README.md
+++ b/wcc-contentful/README.md
@@ -211,6 +211,66 @@ class MyJob < ApplicationJob
 end
 ```
 
+## Test Helpers
+
+To use the test helpers, include the following in your rails_helper.rb:
+
+```ruby
+require 'wcc/contentful/rspec'
+```
+
+This adds the following helpers to all your specs:
+
+```ruby
+##
+# Builds a in-memory instance of the Contentful model for the given content_type.
+# All attributes that are known to be required fields on the content type
+# will return a default value based on the field type.
+instance = contentful_create('my-content-type', my_field: 'some-value')
+# => #<WCC::Contentful::Model::MyContentType:0x0000000005c71a78 @created_at=2018-04-16 18:41:17 UTC...>
+
+instance.my_field
+# => "some-value"
+
+instance.other_required_field
+# => "default-value"
+
+instance.other_optional_field
+# => nil
+
+instance.not_a_field
+# NoMethodError: undefined method `not_a_field' for #<Menu:0x00007fbac81ee490>
+
+##
+# Builds a rspec double of the Contentful model for the given content_type.
+# All attributes that are known to be required fields on the content type
+# will return a default value based on the field type.
+dbl = contentful_double('my-content-type', my_field: 'other-value')
+# => #<Double (anonymous)>
+
+dbl.my_field
+# => "other-value"
+
+dbl.not_a_field
+# => #<Double (anonymous)> received unexpected message :not_a_field with (no args)
+
+##
+# Builds out a fake Contentful entry for the given content type, and then
+# stubs the Model API to return that content type for `.find` and `.find_by`
+# query methods.
+stubbed = contentful_stub('my-content-type', id: '1234', my_field: 'test')
+
+WCC::Contentful::Model.find('1234') == stubbed
+# => true
+
+MyContentType.find('1234') == stubbed
+# => true
+
+MyContentType.find_by(my_field: 'test') == stubbed
+# => true
+```
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/wcc-contentful/lib/wcc/contentful/rspec.rb
+++ b/wcc-contentful/lib/wcc/contentful/rspec.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
+require 'wcc/contentful'
+
 require_relative './test'
 
 module WCC::Contentful::RSpec
   include WCC::Contentful::Test::Double
   include WCC::Contentful::Test::Factory
 
+  ##
+  # Builds out a fake Contentful entry for the given content type, and then
+  # stubs the Model API to return that content type for `.find` and `.find_by`
+  # query methods.
   def contentful_stub(content_type, **attrs)
     const = WCC::Contentful::Model.resolve_constant(content_type.to_s)
     instance = contentful_create(content_type, **attrs)
@@ -28,6 +34,8 @@ module WCC::Contentful::RSpec
   end
 end
 
-RSpec.configure do |config|
-  config.include WCC::Contentful::RSpec
+if defined?(RSpec)
+  RSpec.configure do |config|
+    config.include WCC::Contentful::RSpec
+  end
 end

--- a/wcc-contentful/lib/wcc/contentful/rspec.rb
+++ b/wcc-contentful/lib/wcc/contentful/rspec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative './test'
+
+module WCC::Contentful::RSpec
+  include WCC::Contentful::Test::Double
+  include WCC::Contentful::Test::Factory
+
+  def contentful_stub(content_type, **attrs)
+    const = WCC::Contentful::Model.resolve_constant(content_type.to_s)
+    instance = contentful_create(content_type, **attrs)
+
+    allow(WCC::Contentful::Model).to receive(:find)
+      .with(instance.id)
+      .and_return(instance)
+    allow(WCC::Contentful::Model).to receive(:find)
+      .with(instance.id, anything)
+      .and_return(instance)
+    allow(const).to receive(:find) { |id, options| WCC::Contentful::Model.find(id, options) }
+
+    attrs.each do |k, v|
+      allow(const).to receive(:find_by)
+        .with(hash_including(k => v))
+        .and_return(instance)
+    end
+
+    instance
+  end
+end
+
+RSpec.configure do |config|
+  config.include WCC::Contentful::RSpec
+end

--- a/wcc-contentful/lib/wcc/contentful/test.rb
+++ b/wcc-contentful/lib/wcc/contentful/test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WCC::Contentful::Test
+end
+
+require_relative 'test/double'
+require_relative 'test/factory'

--- a/wcc-contentful/lib/wcc/contentful/test/attributes.rb
+++ b/wcc-contentful/lib/wcc/contentful/test/attributes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module WCC::Contentful::Test::Attributes
+  DEFAULTS = {
+    String: 'test',
+    Int: 0,
+    Float: 0.0,
+    DateTime: Time.at(0),
+    Boolean: false,
+    Json: -> { OpenStruct.new },
+    Coordinates: -> { OpenStruct.new }
+  }.freeze
+
+  class << self
+    def [](key)
+      DEFAULTS[key]
+    end
+
+    ##
+    # Get a hash of default values for all attributes unique to the given Contentful model.
+    def defaults(const)
+      unless const < WCC::Contentful::Model
+        raise ArgumentError, "#{const} is not a subclass of WCC::Contentful::Model"
+      end
+
+      const.content_type_definition.fields.each_with_object({}) do |(name, f), h|
+        h[name.to_sym] = h[name.underscore.to_sym] = default_value(f)
+      end
+    end
+
+    ##
+    # Gets the default value for a contentful IndexedRepresentation::Field.
+    # This comes from the 'content_type_definition' of a contentful model class.
+    def default_value(field)
+      return [] if field.array
+      return unless field.required
+
+      val = DEFAULTS[field]
+      return val.call if val.respond_to?(:call)
+
+      val
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/test/double.rb
+++ b/wcc-contentful/lib/wcc/contentful/test/double.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative './attributes'
+
+module WCC::Contentful::Test::Double
+  ##
+  # Builds a rspec double of the Contentful model for the given content_type.
+  # All attributes that are known to be required fields on the content type
+  # will return a default value based on the field type.
+  def contentful_double(content_type, **attrs)
+    const = WCC::Contentful::Model.resolve_constant(content_type)
+    attrs.symbolize_keys!
+
+    bad_attrs = attrs.reject { |a| const.instance_methods.include?(a) }
+    raise ArgumentError, "Attribute(s) do not exist on #{const}: #{bad_attrs.keys}" if bad_attrs.any?
+
+    double(attrs[:name] || attrs[:id] || nil, defaults(const).merge(attrs))
+  end
+
+  ##
+  # Builds an rspec double of a Contentful image asset, including the file
+  # URL and details.  These fields can be overridden.
+  def contentful_image_double(**attrs)
+    attrs = {
+      title: WCC::Contentful::Test::Attributes[:String],
+      description: WCC::Contentful::Test::Attributes[:String],
+      file: {
+        url: '//images.ctfassets.net/7yx6/2rak/test.jpg',
+        details: {
+          image: {
+            width: 0,
+            height: 0
+          }
+        }
+      }
+    }.deep_merge!(attrs)
+
+    attrs[:file] = OpenStruct.new(attrs[:file]) if attrs[:file]
+
+    attrs[:raw] = {
+      sys: {
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: ENV['CONTENTFUL_SPACE_ID']
+          }
+        },
+        id: SecureRandom.urlsafe_base64,
+        type: 'Asset',
+        createdAt: Time.now.to_s(:iso8601),
+        updatedAt: Time.now.to_s(:iso8601),
+        environment: {
+          sys: {
+            id: 'master',
+            type: 'Link',
+            linkType: 'Environment'
+          }
+        },
+        revision: rand(100),
+        locale: 'en-US'
+      },
+      fields: attrs.each_with_object({}) { |(k, v), h| h[k] = { 'en-US' => v } }
+    }
+
+    double(attrs)
+  end
+
+  private
+
+  def defaults(model)
+    attributes = WCC::Contentful::Test::Attributes.defaults(model)
+    methods = model.instance_methods - WCC::Contentful::Model.instance_methods
+    methods.each_with_object(attributes) { |f, h| h[f] ||= nil }
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/test/factory.rb
+++ b/wcc-contentful/lib/wcc/contentful/test/factory.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative './attributes'
+
+module WCC::Contentful::Test::Factory
+  ##
+  # Builds a in-memory instance of the Contentful model for the given content_type.
+  # All attributes that are known to be required fields on the content type
+  # will return a default value based on the field type.
+  def contentful_create(content_type, **attrs)
+    const = WCC::Contentful::Model.resolve_constant(content_type.to_s)
+    attrs = attrs.transform_keys { |a| a.to_s.camelize(:lower) }
+
+    id = attrs.delete('id')
+    bad_attrs = attrs.reject { |a| const.content_type_definition.fields.key?(a) }
+    raise ArgumentError, "Attribute(s) do not exist on #{const}: #{bad_attrs.keys}" if bad_attrs.any?
+
+    default_instance(const, id).tap do |instance|
+      attrs.each do |k, v|
+        field = const.content_type_definition.fields[k]
+
+        raw = v
+        if %i[Asset Link].include?(field.type)
+          raw = to_raw(v, field.type)
+
+          unless field.array ? v.any? { |i| i.is_a?(String) } : v.is_a?(String)
+            instance.instance_variable_set("@#{field.name}_resolved", v)
+          end
+        end
+
+        instance.raw['fields'][field.name][instance.sys.locale] = raw
+        instance.instance_variable_set("@#{field.name}", raw)
+      end
+
+      def instance.to_s
+        "#<#{self.class.name} id=\"#{id}\">"
+      end
+    end
+  end
+
+  class Link
+    attr_reader :id
+    attr_reader :link_type
+    attr_reader :raw
+
+    LINK_TYPES = {
+      Asset: 'Asset',
+      Link: 'Entry'
+    }.freeze
+
+    def initialize(model, link_type = nil)
+      @id = model.try(:id) || model
+      @link_type = link_type
+      @link_type ||= model.is_a?(WCC::Contentful::Model::Asset) ? :Asset : :Link
+      @raw =
+        {
+          'sys' => {
+            'type' => 'Link',
+            'linkType' => LINK_TYPES[@link_type],
+            'id' => @id
+          }
+        }
+    end
+
+    alias_method :to_h, :raw
+  end
+
+  private
+
+  def default_instance(model, id = nil)
+    model.new(default_raw(model, id))
+  end
+
+  def default_raw(model, id = nil)
+    { sys: sys(model, id), fields: fields(model) }.as_json
+  end
+
+  def sys(model, id = nil)
+    {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: ENV['CONTENTFUL_SPACE_ID']
+        }
+      },
+      id: id || SecureRandom.urlsafe_base64,
+      type: 'Entry',
+      createdAt: Time.now.to_s(:iso8601),
+      updatedAt: Time.now.to_s(:iso8601),
+      environment: {
+        sys: {
+          id: 'master',
+          type: 'Link',
+          linkType: 'Environment'
+        }
+      },
+      revision: rand(100),
+      contentType: {
+        sys: {
+          type: 'Link',
+          linkType: 'ContentType',
+          id: model.content_type
+        }
+      },
+      locale: 'en-US'
+    }
+  end
+
+  def fields(model)
+    WCC::Contentful::Test::Attributes.defaults(model).each_with_object({}) do |(k, v), h|
+      h[k] = { 'en-US' => v }
+    end
+  end
+
+  def to_raw(val, field_type)
+    if val.is_a? Array
+      val.map { |i| to_raw(i, field_type) }
+    elsif val.is_a? String
+      Link.new(val, field_type).raw
+    elsif val
+      val.raw
+    end
+  end
+end


### PR DESCRIPTION
Adds a few test helpers to your specs.  Include them by adding this to your spec helper:

```ruby
# spec_helper.rb
require 'wcc/contentful/rspec'
```

Documentation can be viewed at README.md#test-helpers