### PR TITLE
Rake release tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /coverage/
 /doc/
 /pkg/
+*/pkg/
 /spec/reports/
 /tmp/
 

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,9 @@ namespace :bump do
   Bump::Bump::BUMPS.each do |bump|
     task bump do
       sync_versions
+
+      system('find . -type f -name version.rb | xargs git add')
+      system("git commit -m 'Release v#{Bump::Bump.current}'")
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,3 +26,26 @@ namespace :bump do
     end
   end
 end
+
+require "bundler/gem_helper"
+
+gems = [
+  'wcc-contentful',
+  'wcc-contentful-app'
+]
+
+gems.each do |name|
+  namespace name do
+    Dir.chdir(name) do
+      Bundler::GemHelper.install_tasks
+    end
+  end
+end
+
+desc "Create tag and build and push all gems\n" \
+  "To prevent publishing in RubyGems use `gem_push=no rake release`"
+task release: [:check].concat(gems.map { |g| "#{g}:release" })
+desc "Build #{gems.join(',')} into the pkg directory."
+task build: gems.map { |g| "#{g}:build" }
+task install: gems.map { |g| "#{g}:install" }
+task "install:local" => gems.map { |g| "#{g}:install:local" }

--- a/wcc-contentful-app/lib/wcc/contentful/app/version.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/version.rb
@@ -3,7 +3,7 @@
 module WCC
   module Contentful
     module App
-      VERSION = '0.4.0-beta'
+      VERSION = '0.4.0-rc'
     end
   end
 end

--- a/wcc-contentful/lib/wcc/contentful/version.rb
+++ b/wcc-contentful/lib/wcc/contentful/version.rb
@@ -2,6 +2,6 @@
 
 module WCC
   module Contentful
-    VERSION = '0.4.0-beta'
+    VERSION = '0.4.0-rc'
   end
 end


### PR DESCRIPTION
* Adds git commands after version bump to commit the resulting version file change
* Adds a `rake release` task to the root directory which pushes the gems in each subdir

The new release process is now:
1. `rake bump:{major, minor, pre}` # updates the `version.rb` files and commits the change
2. `rake release` # tags the bump commit and pushes the new gem to rubygems.org.

Resulting commit looks like:
```diff
$ git show v0.4.0.pre.rc
tag v0.4.0.pre.rc
Tagger: Gordon <gburgett@watermark.org>
Date:   Mon Oct 22 10:17:13 2018 -0500

Version 0.4.0.pre.rc

commit 6fc20288f36398c08c8f99e56b811af61feef1a6
Author: Gordon <gburgett@watermark.org>
Date:   Mon Oct 22 10:16:15 2018 -0500

    Release v0.4.0-rc

diff --git a/wcc-contentful-app/lib/wcc/contentful/app/version.rb b/wcc-contentful-app/lib/wcc/contentful/app/version.rb
index e022478..a4abadf 100644
--- a/wcc-contentful-app/lib/wcc/contentful/app/version.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/version.rb
@@ -3,7 +3,7 @@
 module WCC
   module Contentful
     module App
-      VERSION = '0.4.0-beta'
+      VERSION = '0.4.0-rc'
     end
   end
 end
diff --git a/wcc-contentful/lib/wcc/contentful/version.rb b/wcc-contentful/lib/wcc/contentful/version.rb
index 9b5ec23..95999dd 100644
--- a/wcc-contentful/lib/wcc/contentful/version.rb
+++ b/wcc-contentful/lib/wcc/contentful/version.rb
@@ -2,6 +2,6 @@
 
 module WCC
   module Contentful
-    VERSION = '0.4.0-beta'
+    VERSION = '0.4.0-rc'
   end
 end

```