### PR TITLE
86 section partial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,3 +66,4 @@ jobs:
       - type: shell
         command: |
           bundle exec rubocop
+      - run: bundle exec erblint '*/app/views/**/*.erb'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,34 @@
+---
+exclude:
+  # SVG images rendered in erb templates
+  # Special script that needs to break the rules
+linters:
+  AllowedScriptType:
+    enabled: true
+    disallow_inline_scripts: true
+  ErbSafety:
+    enabled: true
+  FinalNewline:
+    enabled: true
+  NoJavascriptTagHelper:
+    enabled: true
+  RightTrim:
+    enabled: true
+  SpaceAroundErbTag:
+    enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingBlankLines:
+        Enabled: false
+      # TODO:
+      Naming/FileName:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -27,7 +27,6 @@ linters:
         Enabled: false
       Layout/TrailingBlankLines:
         Enabled: false
-      # TODO:
       Naming/FileName:
         Enabled: false
       Lint/UselessAssignment:

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,11 @@ source 'https://rubygems.org'
 group :development, :test do
   gem 'bump', '~> 0.6.1'
   gem 'danger-wcc', '~> 0.0.5'
+  gem 'erb_lint'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-rubocop'
+  gem 'guard-shell', '~> 0.7.1'
   gem 'rake', '~> 12.3'
   gem 'rubocop'
 end

--- a/wcc-contentful-app/app/controllers/wcc/contentful/app/pages_controller.rb
+++ b/wcc-contentful-app/app/controllers/wcc/contentful/app/pages_controller.rb
@@ -5,6 +5,6 @@ class WCC::Contentful::App::PagesController < ApplicationController
 
   def show
     @page = WCC::Contentful::Model::Page.find_by(slug: '/' + params[:slug], options: { include: 3 })
-    raise ::Exceptions::PageNotFoundError, '/' + params[:slug] unless @page
+    raise WCC::Contentful::App::PageNotFoundError, '/' + params[:slug] unless @page
   end
 end

--- a/wcc-contentful-app/app/controllers/wcc/contentful/app/pages_controller.rb
+++ b/wcc-contentful-app/app/controllers/wcc/contentful/app/pages_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class WCC::Contentful::App::PagesController < ApplicationController
+  helper SectionHelper
+
+  def show
+    @page = WCC::Contentful::Model::Page.find_by(slug: '/' + params[:slug], options: { include: 3 })
+    raise ::Exceptions::PageNotFoundError, '/' + params[:slug] unless @page
+  end
+end

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -20,4 +20,9 @@ module WCC::Contentful::App::SectionHelper
     end
     section_styles
   end
+
+  def section_id(section)
+    title = section.try(:bookmark_title) || section.try(:title)
+    CGI.escape(title.gsub(/\W+/, '-')) if title.present?
+  end
 end

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WCC::Contentful::App::SectionHelper
+  def section_template_name(section)
+    section.class.name.demodulize.underscore.sub('section_', '')
+  end
+
+  def section_css_name(section)
+    section_template_name(section).dasherize
+  end
+
+  def section_styles(section)
+    section_styles = ['section-' + section_css_name(section)]
+    if styles = section.try(:styles)
+      section_styles.push(styles.map { |style| style.downcase.gsub(/[^\w]/, '-') })
+    elsif style = section.try(:style)
+      section_styles.push(style.downcase.gsub(/[^\w]/, '-'))
+    else
+      section_styles.push('default')
+    end
+    section_styles
+  end
+end

--- a/wcc-contentful-app/app/views/components/_menu-item.html.erb
+++ b/wcc-contentful-app/app/views/components/_menu-item.html.erb
@@ -1,4 +1,5 @@
 <% return '' unless item
+
    classes ||= ['nav-item']
    classes.push('active') if item_active?(item)
    classes.push('dropdown') if dropdown?(item) %>
@@ -12,11 +13,13 @@
 
     <div class='dropdown-menu'>
       <% item.items.each do |dropdown_item| %>
-        <%= render_button(dropdown_item, class: 'dropdown-item', data: { toggle: "collapse", target: "#navbar" }) %>
+        <%= render_button(dropdown_item,
+              class: 'dropdown-item',
+              data: { toggle: 'collapse', target: '#navbar' }) %>
       <% end %>
     </div>
   <% elsif item.respond_to?(:href) %>
-    <%= render_button(item, class: 'nav-link', data: { toggle: "collapse", target: "#navbar" }) %>
+    <%= render_button(item, class: 'nav-link', data: { toggle: 'collapse', target: '#navbar' }) %>
   <% else %>
     <%# divider %>
     <span class="divider <%= item.style %>">

--- a/wcc-contentful-app/app/views/components/_section.html.erb
+++ b/wcc-contentful-app/app/views/components/_section.html.erb
@@ -1,0 +1,7 @@
+<%
+  styles ||= []
+  styles.push(*section_styles(section))
+%>
+<%= content_tag(:section, class: styles) do %>
+  <%= render("sections/#{section_template_name(section)}", section: section) %>
+<% end %>

--- a/wcc-contentful-app/app/views/components/_section.html.erb
+++ b/wcc-contentful-app/app/views/components/_section.html.erb
@@ -1,14 +1,12 @@
-<%
-  styles ||= []
-  styles.push(*section_styles(section))
-  section_prefixes ||= nil
-  section_name = section_template_name(section)
-%>
+<% styles ||= []
+   styles.push(*section_styles(section))
+   section_prefixes ||= nil
+   section_name = section_template_name(section) %>
 <%= content_tag(:section, class: styles, id: section_id(section)) do %>
   <% if section_prefixes && lookup_context.exists?(section_name, [*section_prefixes], true) %>
     <%= render([*section_prefixes, section_name].join('/'), section: section) %>
   <% else %>
     <%= render("sections/#{section_name}", section: section) %>
   <% end %>
-  
+
 <% end %>

--- a/wcc-contentful-app/app/views/components/_section.html.erb
+++ b/wcc-contentful-app/app/views/components/_section.html.erb
@@ -1,7 +1,14 @@
 <%
   styles ||= []
   styles.push(*section_styles(section))
+  section_prefixes ||= nil
+  section_name = section_template_name(section)
 %>
 <%= content_tag(:section, class: styles, id: section_id(section)) do %>
-  <%= render("sections/#{section_template_name(section)}", section: section) %>
+  <% if section_prefixes && lookup_context.exists?(section_name, [*section_prefixes], true) %>
+    <%= render([*section_prefixes, section_name].join('/'), section: section) %>
+  <% else %>
+    <%= render("sections/#{section_name}", section: section) %>
+  <% end %>
+  
 <% end %>

--- a/wcc-contentful-app/app/views/components/_section.html.erb
+++ b/wcc-contentful-app/app/views/components/_section.html.erb
@@ -2,6 +2,6 @@
   styles ||= []
   styles.push(*section_styles(section))
 %>
-<%= content_tag(:section, class: styles) do %>
+<%= content_tag(:section, class: styles, id: section_id(section)) do %>
   <%= render("sections/#{section_template_name(section)}", section: section) %>
 <% end %>

--- a/wcc-contentful-app/app/views/wcc/contentful/app/pages/show.html.erb
+++ b/wcc-contentful-app/app/views/wcc/contentful/app/pages/show.html.erb
@@ -1,0 +1,5 @@
+<% @page.sections&.each_with_index do |section, index|
+  next if section.nil?
+  %>
+  <%= render("components/section", section: section, index: index) %>
+<% end %>

--- a/wcc-contentful-app/app/views/wcc/contentful/app/pages/show.html.erb
+++ b/wcc-contentful-app/app/views/wcc/contentful/app/pages/show.html.erb
@@ -1,5 +1,4 @@
 <% @page.sections&.each_with_index do |section, index|
-  next if section.nil?
-  %>
-  <%= render("components/section", section: section, index: index) %>
+  next if section.nil? %>
+  <%= render('components/section', section: section, index: index) %>
 <% end %>

--- a/wcc-contentful-app/config/routes.rb
+++ b/wcc-contentful-app/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 WCC::Contentful::App::Engine.routes.draw do
+  get '/:slug', to: 'pages#show'
 end

--- a/wcc-contentful-app/lib/wcc/contentful/app/exceptions.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/exceptions.rb
@@ -33,4 +33,13 @@ module WCC::Contentful::App
       ret.flatten(1)
     end
   end
+
+  class PageNotFoundError < StandardError
+    attr_reader :slug
+
+    def initialize(slug)
+      super("Page not found: '#{slug}'")
+      @slug = slug
+    end
+  end
 end

--- a/wcc-contentful-app/lib/wcc/contentful/app/rails.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/rails.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require 'wcc/rails'
+require 'wcc/contentful/rails'
 require 'wcc/contentful/app'
 require 'wcc/contentful/app/engine'

--- a/wcc-contentful-app/spec/controllers/wcc/contentful/app/pages_controller_spec.rb
+++ b/wcc-contentful-app/spec/controllers/wcc/contentful/app/pages_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
+  routes { WCC::Contentful::App::Engine.routes }
+
+  it 'loads page by slug' do
+    page = contentful_stub('page', slug: '/test')
+
+    get :show, params: { slug: 'test' }
+
+    expect(assigns(:page)).to eq(page)
+  end
+end

--- a/wcc-contentful-app/spec/controllers/wcc/contentful/app/pages_controller_spec.rb
+++ b/wcc-contentful-app/spec/controllers/wcc/contentful/app/pages_controller_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
 
     expect(assigns(:page)).to eq(page)
   end
+
+  it 'raises exception when page not found' do
+    expect(WCC::Contentful::Model::Page).to receive(:find_by)
+      .and_return(nil)
+
+    expect {
+      get :show, params: { slug: 'not-found' }
+    }.to raise_error(WCC::Contentful::App::PageNotFoundError)
+  end
 end

--- a/wcc-contentful-app/spec/dummy/config/routes.rb
+++ b/wcc-contentful-app/spec/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount WCC::Contentful::App::Engine, at: '/wcc/contentful/app'
+  mount WCC::Contentful::App::Engine, at: '/'
 end

--- a/wcc-contentful-app/spec/fixtures/contentful/content_types_mgmt_api.json
+++ b/wcc-contentful-app/spec/fixtures/contentful/content_types_mgmt_api.json
@@ -340,6 +340,27 @@
           "omitted": false
         },
         {
+          "id": "styles",
+          "name": "Styles",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": [
+                  "rounded",
+                  "vertical"
+                ]
+              }
+            ]
+          }
+        },
+        {
           "id": "youtubeLink",
           "name": "youtubeLink",
           "type": "Symbol",
@@ -1347,6 +1368,23 @@
           "type": "Text",
           "localized": false,
           "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "style",
+          "name": "Style",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "in": [
+                "default",
+                "light"
+              ]
+            }
+          ],
           "disabled": false,
           "omitted": false
         },

--- a/wcc-contentful-app/spec/rails_helper.rb
+++ b/wcc-contentful-app/spec/rails_helper.rb
@@ -18,10 +18,10 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 require 'wcc/contentful/app/rails'
 
 # require rspec-rails to simulate framework behavior in specs
-# require 'rails-controller-testing'
+require 'rails-controller-testing'
 require 'rspec/rails'
-# require 'capybara/rspec'
-# require 'capybara/rails'
+require 'capybara/rspec'
+require 'capybara/rails'
 
 ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')
 

--- a/wcc-contentful-app/spec/views/components/_section.html.erb_spec.rb
+++ b/wcc-contentful-app/spec/views/components/_section.html.erb_spec.rb
@@ -5,18 +5,9 @@ require 'rails_helper'
 RSpec.describe 'components/section' do
   helper WCC::Contentful::App::SectionHelper
 
-  before do
-    allow(view).to receive(:render).and_wrap_original do |m, *args|
-      if args[0].is_a?(String) && /^sections\/(\S+)/ =~ args[0]
-        "<#{args.dig(1, :section).class.name} />".html_safe
-      else
-        m.call(*args)
-      end
-    end
-  end
-
   it 'renders the given section with empty styles' do
     faq = contentful_create('section-Faq')
+    stub_template 'sections/_faq.html.erb' => '<FAQ />'
 
     render partial: 'components/section', locals: { section: faq }
 
@@ -26,6 +17,7 @@ RSpec.describe 'components/section' do
   it 'renders the given section with an ID' do
     testimonials = contentful_create('section-Testimonials',
       title: 'Testimonials for Jesus!')
+    stub_template 'sections/_testimonials.html.erb' => '<Testimonials />'
 
     render partial: 'components/section', locals: { section: testimonials }
 
@@ -35,6 +27,7 @@ RSpec.describe 'components/section' do
   it 'renders the section style' do
     faq = contentful_create('section-Faq',
       style: 'light')
+    stub_template 'sections/_faq.html.erb' => '<FAQ />'
 
     render partial: 'components/section', locals: { section: faq }
 
@@ -45,6 +38,7 @@ RSpec.describe 'components/section' do
   it 'renders additional styles' do
     faq = contentful_create('section-Faq',
       style: 'light')
+    stub_template 'sections/_faq.html.erb' => '<FAQ />'
 
     render partial: 'components/section', locals: { section: faq, styles: ['test'] }
 
@@ -54,6 +48,7 @@ RSpec.describe 'components/section' do
   it 'renders style collection' do
     video_highlight = contentful_create('section-VideoHighlight',
       styles: %w[rounded vertical])
+    stub_template 'sections/_videohighlight.html.erb' => '<VideoHighlight />'
 
     render partial: 'components/section', locals: { section: video_highlight }
 
@@ -63,9 +58,38 @@ RSpec.describe 'components/section' do
   it 'renders when style collection is nil' do
     video_highlight = contentful_create('section-VideoHighlight',
       styles: nil)
+    stub_template 'sections/_videohighlight.html.erb' => '<VideoHighlight />'
 
     render partial: 'components/section', locals: { section: video_highlight, styles: ['test'] }
 
     expect(rendered).to have_css('section.section-videohighlight.test')
+  end
+
+  context 'section_prefixes given' do
+    it 'renders the section from the section_prefixes directory when exists' do
+      faq = contentful_create('section-Faq')
+
+      stub_template 'sections-v2/_faq.html.erb' => '<FAQ-v2 />'
+
+      render partial: 'components/section', locals: {
+        section: faq,
+        section_prefixes: 'sections-v2'
+      }
+
+      expect(rendered).to include('<FAQ-v2 />')
+    end
+
+    it "renders from the gem's sections directory when doesn't exist in section_prefixes" do
+      faq = contentful_create('section-Faq')
+
+      stub_template 'sections/_faq.html.erb' => '<FAQ-gem />'
+
+      render partial: 'components/section', locals: {
+        section: faq,
+        section_prefixes: 'sections-v2'
+      }
+
+      expect(rendered).to include('<FAQ-gem />')
+    end
   end
 end

--- a/wcc-contentful-app/spec/views/components/_section.html.erb_spec.rb
+++ b/wcc-contentful-app/spec/views/components/_section.html.erb_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'components/section' do
+  helper WCC::Contentful::App::SectionHelper
+
+  before do
+    allow(view).to receive(:render).and_wrap_original do |m, *args|
+      if args[0].is_a?(String) && /^sections\/(\S+)/ =~ args[0]
+        "<#{args.dig(1, :section).class.name} />".html_safe
+      else
+        m.call(*args)
+      end
+    end
+  end
+
+  it 'renders the given section with empty styles' do
+    faq = contentful_create('section-Faq')
+
+    render partial: 'components/section', locals: { section: faq }
+
+    expect(rendered).to have_css('section.section-faq.default')
+  end
+
+  it 'renders the given section with an ID' do
+    testimonials = contentful_create('section-Testimonials',
+      title: 'Testimonials for Jesus!')
+
+    render partial: 'components/section', locals: { section: testimonials }
+
+    expect(rendered).to have_css('#Testimonials-for-Jesus-')
+  end
+
+  it 'renders the section style' do
+    faq = contentful_create('section-Faq',
+      style: 'light')
+
+    render partial: 'components/section', locals: { section: faq }
+
+    expect(rendered).to have_css('section.section-faq.light')
+    expect(rendered).to_not have_css('section.default')
+  end
+
+  it 'renders additional styles' do
+    faq = contentful_create('section-Faq',
+      style: 'light')
+
+    render partial: 'components/section', locals: { section: faq, styles: ['test'] }
+
+    expect(rendered).to have_css('section.section-faq.light.test')
+  end
+
+  it 'renders style collection' do
+    video_highlight = contentful_create('section-VideoHighlight',
+      styles: %w[rounded vertical])
+
+    render partial: 'components/section', locals: { section: video_highlight }
+
+    expect(rendered).to have_css('section.section-videohighlight.rounded.vertical')
+  end
+
+  it 'renders when style collection is nil' do
+    video_highlight = contentful_create('section-VideoHighlight',
+      styles: nil)
+
+    render partial: 'components/section', locals: { section: video_highlight, styles: ['test'] }
+
+    expect(rendered).to have_css('section.section-videohighlight.test')
+  end
+end

--- a/wcc-contentful-app/spec/views/wcc/contentful/app/pages/show.html.erb_spec.rb
+++ b/wcc-contentful-app/spec/views/wcc/contentful/app/pages/show.html.erb_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'wcc/contentful/app/pages/show' do
+  it 'renders empty when no sections present' do
+    assign(:page, contentful_create('page', sections: []))
+
+    render template: 'wcc/contentful/app/pages/show'
+
+    expect(rendered).to_not have_selector('section')
+  end
+
+  it 'renders multiple sections' do
+    allow(view).to receive(:render)
+      .with({ template: 'wcc/contentful/app/pages/show' }, {})
+      .and_call_original
+
+    faq = contentful_create('section-Faq')
+    expect(view).to receive(:render)
+      .with('components/section', { section: faq, index: 0 })
+
+    testimonial = contentful_create('section-Testimonials')
+    expect(view).to receive(:render)
+      .with('components/section', { section: testimonial, index: 2 })
+
+    assign(:page,
+      contentful_create('page',
+        sections: [
+          faq,
+          nil,
+          testimonial
+        ]))
+
+    render template: 'wcc/contentful/app/pages/show'
+  end
+end

--- a/wcc-contentful-app/wcc-contentful-app.gemspec
+++ b/wcc-contentful-app/wcc-contentful-app.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'capybara', '~> 3.9'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'dotenv', '~> 2.2'
+  spec.add_development_dependency 'erb_lint', '~> 0.0.26'
   spec.add_development_dependency 'httplog', '~> 1.0'
   spec.add_development_dependency 'rails-controller-testing', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'
@@ -41,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.3.0'
+  spec.add_development_dependency 'guard-shell', '~> 0.7.1'
 
   # for generators
   spec.add_development_dependency 'generator_spec', '~> 0.9.4'

--- a/wcc-contentful-app/wcc-contentful-app.gemspec
+++ b/wcc-contentful-app/wcc-contentful-app.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'dotenv', '~> 2.2'
   spec.add_development_dependency 'httplog', '~> 1.0'
+  spec.add_development_dependency 'rails-controller-testing', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'

--- a/wcc-contentful-app/wcc-contentful-app.gemspec
+++ b/wcc-contentful-app/wcc-contentful-app.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'capybara', '~> 3.9'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'dotenv', '~> 2.2'
   spec.add_development_dependency 'httplog', '~> 1.0'

--- a/wcc-contentful/Guardfile
+++ b/wcc-contentful/Guardfile
@@ -3,6 +3,39 @@
 
 # To run, use `bundle exec guard`.
 
+def watch_async(regexp)
+  raise ArgumentError, "No block given" unless block_given?
+  match_queue = Queue.new
+  
+  watch(regexp) do |match|
+    # Producer - add matches to the match queue
+    match_queue << match
+    nil
+  end
+
+  # Consumer - process matches as a batch
+  Thread.new do
+    loop do
+      matches = []
+      matches << match_queue.pop
+
+      loop do
+        begin
+          matches << match_queue.pop(true)
+        rescue ThreadError
+          break
+        end
+      end
+
+      begin
+        yield matches if matches.length > 0
+      rescue StandardError => ex
+        STDERR.puts "Error! #{ex}"
+      end
+    end
+  end
+end
+
 group :red_green_refactor, halt_on_fail: true do
   guard :rspec, cmd: 'bundle exec rspec' do
     require 'guard/rspec/dsl'
@@ -45,6 +78,16 @@ group :red_green_refactor, halt_on_fail: true do
   guard :rubocop, cli: ['--display-cop-names'] do
     watch(%r{.+\.rb$})
     watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+  end
+
+  guard :shell, all_on_start: false do
+    watch_async(%r{app/views/(.+\.html.*\.erb)}) { |matches|
+      
+      matches = matches.map { |m| File.absolute_path(m[0]) }
+      Dir.chdir('..') {
+        system("bundle exec erblint #{matches.join(' ')}")
+      }
+    }
   end
 end
 

--- a/wcc-contentful/wcc-contentful.gemspec
+++ b/wcc-contentful/wcc-contentful.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'dotenv', '~> 2.2'
+  spec.add_development_dependency 'erb_lint', '~> 0.0.26'
   spec.add_development_dependency 'httplog', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
@@ -39,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.3.0'
+  spec.add_development_dependency 'guard-shell', '~> 0.7.1'
 
   # for generators
   spec.add_development_dependency 'generator_spec', '~> 0.9.4'


### PR DESCRIPTION
* Add PagesController to wcc-contentful-app engine.  Apps should now mount the app engine at the bottom of the routes file, ex:

```rb
mount WCC::Contentful::App::Engine, at: '/'  # replaces get '/*slug', to: 'pages#show'
```

* Provides a default `pages/show.html.erb` view which renders each section in turn
* Provides a `components/section` partial which renders a section, and can be used as follows if an app chooses to override `pages/show`:

```erb
<% @page.sections&.each_with_index do |section, index|
  next if section.nil?
  %>
  <%= render("components/section",
    section_prefixes: "sections-v2",  # where to look in the app's view directory before falling back to the gem
    section: section,
    index: index) %>
<% end %>
```

fixes #86 