### PR TITLE
79 key error

### DIFF
--- a/wcc-contentful/app/jobs/wcc/contentful/delayed_sync_job.rb
+++ b/wcc-contentful/app/jobs/wcc/contentful/delayed_sync_job.rb
@@ -33,7 +33,7 @@ module WCC::Contentful
       return unless store.respond_to?(:index)
 
       self.class.mutex.synchronize do
-        next_sync_token = store.find('sync:token')&.fetch('token')
+        next_sync_token = store.find('sync:token')&.fetch('token', nil)
         sync_resp = client.sync(sync_token: next_sync_token)
 
         id_found = up_to_id.nil?

--- a/wcc-contentful/app/jobs/wcc/contentful/delayed_sync_job.rb
+++ b/wcc-contentful/app/jobs/wcc/contentful/delayed_sync_job.rb
@@ -45,7 +45,7 @@ module WCC::Contentful
           store.index(item)
           count += 1
         end
-        store.set('sync:token', token: sync_resp.next_sync_token)
+        store.set('sync:token', 'token' => sync_resp.next_sync_token)
 
         logger.info "Synced #{count} entries.  Next sync token:\n  #{sync_resp.next_sync_token}"
         logger.info "Should enqueue again? [#{!id_found}]"

--- a/wcc-contentful/spec/jobs/wcc/contentful/delayed_sync_job_spec.rb
+++ b/wcc-contentful/spec/jobs/wcc/contentful/delayed_sync_job_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe WCC::Contentful::DelayedSyncJob, type: :job do
                       ))
 
         expect(WCC::Contentful::Services.instance.store).to receive(:set)
-          .with('sync:token', { token: 'test' })
+          .with('sync:token', { 'token' => 'test' })
         expect(WCC::Contentful::Services.instance.store).to_not receive(:index)
 
         # act
@@ -55,7 +55,7 @@ RSpec.describe WCC::Contentful::DelayedSyncJob, type: :job do
 
         items = next_sync['items']
         expect(WCC::Contentful::Services.instance.store).to receive(:set)
-          .with('sync:token', { token: 'test2' })
+          .with('sync:token', { 'token' => 'test2' })
         expect(WCC::Contentful::Services.instance.store).to receive(:index)
           .exactly(items.count).times
 
@@ -107,6 +107,32 @@ RSpec.describe WCC::Contentful::DelayedSyncJob, type: :job do
 
       # act
       job.sync!(up_to_id: nil)
+    end
+
+    it 'continues from prior sync token with LazyCacheStore' do
+      allow(WCC::Contentful::Services.instance).to receive(:store)
+        .and_return(WCC::Contentful::Store::LazyCacheStore.new(client))
+
+      allow(client).to receive(:sync)
+        .with({ sync_token: nil })
+        .and_return(double(
+                      items: [],
+                      next_sync_token: 'test'
+                    ))
+      expect(client).to receive(:sync)
+        .with({ sync_token: 'test' })
+        .and_return(double(
+                      items: [],
+                      next_sync_token: 'test2'
+                    ))
+
+      # act
+      synced = job.sync!
+      synced2 = job.sync!
+
+      # assert
+      expect(synced).to eq('test')
+      expect(synced2).to eq('test2')
     end
   end
 

--- a/wcc-contentful/spec/jobs/wcc/contentful/delayed_sync_job_spec.rb
+++ b/wcc-contentful/spec/jobs/wcc/contentful/delayed_sync_job_spec.rb
@@ -134,6 +134,26 @@ RSpec.describe WCC::Contentful::DelayedSyncJob, type: :job do
       expect(synced).to eq('test')
       expect(synced2).to eq('test2')
     end
+
+    it 'ignores a poison sync token in the store' do
+      allow(WCC::Contentful::Services.instance).to receive(:store)
+        .and_return(WCC::Contentful::Store::LazyCacheStore.new(client))
+
+      store.set('sync:token', poison: 'poison')
+
+      expect(client).to receive(:sync)
+        .with({ sync_token: nil })
+        .and_return(double(
+                      items: [],
+                      next_sync_token: 'test'
+                    ))
+
+      # act
+      synced = job.sync!
+
+      # assert
+      expect(synced).to eq('test')
+    end
   end
 
   describe 'Perform' do


### PR DESCRIPTION
DelayedSyncJob now properly stores the sync token when using the LazyCacheStore

fixes #79