### PR TITLE
safe-line-break

### DIFF
--- a/wcc-contentful-app/app/assets/stylesheets/_wcc-contentful-app.scss
+++ b/wcc-contentful-app/app/assets/stylesheets/_wcc-contentful-app.scss
@@ -1,3 +1,7 @@
 @import './components/menu-item';
 
 @import './sections/faq';
+
+.safe-line-break {
+  white-space: pre-line;
+}

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -58,7 +58,7 @@ module WCC::Contentful::App::SectionHelper
     text = CGI.escapeHTML(text)
     text = text.gsub(/\&amp;(nbsp|vert|\#\d+);/, '&\1;')
       .gsub(/\&lt;br\/?\&gt;/, '<br/>')
-    text.html_safe
+    content_tag(:span, text.html_safe, class: 'safe-line-break')
   end
 
   def split_content_for_mobile_view(visible_count, speakers)


### PR DESCRIPTION
safe_line_break now wraps the text in a `<span>` tag which includes a corresponding CSS style setting `white-space: pre-wrap`.  This allows newlines in the source text to actually display properly on screen.

refs https://github.com/watermarkchurch/paper-signs/pull/100