### PR TITLE
Unisolate the namespace

### DIFF
--- a/wcc-contentful-app/config/routes.rb
+++ b/wcc-contentful-app/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 WCC::Contentful::App::Engine.routes.draw do
-  get '/*slug', to: 'pages#show'
-  root 'pages#index'
-  post '/contact_form', to: 'contact_form#create', as: :contact_form
+  get '/*slug', to: 'wcc/contentful/app/pages#show'
+  root 'wcc/contentful/app/pages#index'
+  post '/contact_form', to: 'wcc/contentful/app/contact_form#create', as: :contact_form
 end

--- a/wcc-contentful-app/lib/wcc/contentful/app/engine.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/engine.rb
@@ -2,8 +2,6 @@
 
 module WCC::Contentful::App
   class Engine < ::Rails::Engine
-    isolate_namespace WCC::Contentful::App
-
     initializer 'WCC::Contentful::App::Engine.assets' do |app|
       app.config.assets.precompile += %w[*.jpg *.png *.svg]
     end

--- a/wcc-contentful-app/spec/requests/wcc/contentful/app/pages_controller_spec.rb
+++ b/wcc-contentful-app/spec/requests/wcc/contentful/app/pages_controller_spec.rb
@@ -2,16 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
-  routes { WCC::Contentful::App::Engine.routes }
-
+RSpec.describe WCC::Contentful::App::PagesController, type: :request do
   it 'loads homepage off of site config' do
     page = contentful_create('page', slug: '/')
     _config = contentful_stub('siteConfig',
       foreign_key: 'default',
       homepage: page)
 
-    get :index
+    get '/'
 
     expect(response).to render_template('pages/show')
     expect(assigns(:page)).to eq(page)
@@ -22,7 +20,7 @@ RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
     expect(WCC::Contentful::Model::SiteConfig).to receive(:find_by)
       .and_return(nil)
 
-    get :index
+    get '/'
 
     expect(response).to render_template('pages/show')
     expect(assigns(:page)).to eq(page)
@@ -31,7 +29,7 @@ RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
   it 'loads page by slug' do
     page = contentful_stub('page', slug: '/test')
 
-    get :show, params: { slug: 'test' }
+    get '/test'
 
     expect(assigns(:page)).to eq(page)
   end
@@ -43,7 +41,7 @@ RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
       slug: '/test',
       external_link: 'https://www.google.com')
 
-    get :show, params: { slug: 'test' }
+    get '/test'
 
     expect(response).to redirect_to(redirect.external_link)
   end
@@ -55,7 +53,7 @@ RSpec.describe WCC::Contentful::App::PagesController, type: :controller do
       .and_return(nil)
 
     expect {
-      get :show, params: { slug: 'not-found' }
+      get '/not-found'
     }.to raise_error(WCC::Contentful::App::PageNotFoundError)
   end
 end

--- a/wcc-contentful/config/routes.rb
+++ b/wcc-contentful/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 WCC::Contentful::Engine.routes.draw do
-  post 'webhook/receive', to: 'webhook#receive'
+  post 'webhook/receive', to: 'wcc/contentful/webhook#receive'
 end

--- a/wcc-contentful/lib/wcc/contentful/engine.rb
+++ b/wcc-contentful/lib/wcc/contentful/engine.rb
@@ -2,8 +2,6 @@
 
 module WCC::Contentful
   class Engine < ::Rails::Engine
-    isolate_namespace WCC::Contentful
-
     initializer 'enable webhook' do
       config = WCC::Contentful.configuration
       next unless config&.management_token.present?

--- a/wcc-contentful/spec/rails_helper.rb
+++ b/wcc-contentful/spec/rails_helper.rb
@@ -4,11 +4,6 @@ require 'spec_helper'
 
 ENV['RAILS_ENV'] ||= 'test'
 
-# require dummy rails app for engine related specs
-VCR.use_cassette('models/wcc_contentful/content_types/init_mgmt_api', record: :none) do
-  require File.expand_path('dummy/config/environment.rb', __dir__)
-end
-
 # require rails libraries:
 #   railtie includes rails + framework middleware
 #   active_job for any job specs
@@ -17,6 +12,11 @@ require 'active_job'
 
 # require rails specific code
 require 'wcc/contentful/rails'
+
+# require dummy rails app for engine related specs
+VCR.use_cassette('models/wcc_contentful/content_types/init_mgmt_api', record: :none) do
+  require File.expand_path('dummy/config/environment.rb', __dir__)
+end
 
 # require rspec-rails to simulate framework behavior in specs
 require 'rspec/rails'

--- a/wcc-contentful/spec/requests/wcc/contentful/webhook_controller_spec.rb
+++ b/wcc-contentful/spec/requests/wcc/contentful/webhook_controller_spec.rb
@@ -6,17 +6,15 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
   describe 'receive' do
     let!(:good_headers) {
       {
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json',
-        'x-contentful-topic': 'ContentManagement.Entry.publish'
+        'Authorization' => basic_auth('tester1', 'password1'),
+        'Content-Type' => 'application/vnd.contentful.management.v1+json',
+        'x-contentful-topic' => 'ContentManagement.Entry.publish'
       }
     }
 
     let(:body) {
       load_fixture('contentful/contentful_published_blog.json')
     }
-
-    let(:request_headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
     before do
       WCC::Contentful.configure do |config|
@@ -28,28 +26,27 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
     end
 
     it 'denies requests without HTTP BASIC auth' do
-      request.headers['Content-Type'] = 'application/vnd.contentful.management.v1+json'
-
-      post '/wcc/contentful/webhook/receive', body, request_headers
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers.slice('Content-Type')
 
       # assert
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'denies requests with bad HTTP BASIC auth' do
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'badpasswd'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json'
-      )
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers.merge('Authorization' => basic_auth('tester1', 'badpasswd'))
 
       # assert
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'denies requests with bad content type' do
-      request.headers[:Authorization] = basic_auth('tester1', 'password1')
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers.slice('Authorization')
 
       # assert
       expect(response).to have_http_status(:not_acceptable)
@@ -57,35 +54,24 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
     end
 
     it 'denies requests not conforming to contentful object structure' do
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json'
-      )
-
-      post '/wcc/contentful/webhook/receive', '{}'
+      post '/wcc/contentful/webhook/receive',
+        params: '{}',
+        headers: good_headers
 
       # assert
       expect(response).to have_http_status(:bad_request)
     end
 
     it 'returns 204 no content on success' do
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json'
-      )
-
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers
 
       # assert
       expect(response).to have_http_status(:no_content)
     end
 
     it 'immediately updates the store on success' do
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json'
-      )
-
       # expect
       store = double
       expect(store).to receive(:index)
@@ -95,32 +81,25 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
         .and_return(store)
 
       # act
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers
     end
 
     it 'runs a sync on success' do
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json',
-        'x-contentful-topic': 'ContentManagement.Entry.unpublish'
-      )
-
       expect(WCC::Contentful::DelayedSyncJob).to receive(:perform_later)
         .with(hash_including(JSON.parse(body)))
 
       # act
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers
 
       # assert
       expect(response).to have_http_status(:no_content)
     end
 
     it 'runs a sync even in master environment' do
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json'
-      )
-
       WCC::Contentful.configure do |config|
         config.environment = 'staging'
       end
@@ -129,7 +108,9 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
       expect(WCC::Contentful::DelayedSyncJob).to receive(:perform_later)
 
       # act
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers
 
       # assert
       expect(response).to have_http_status(:no_content)
@@ -150,14 +131,10 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
       expect(my_job).to receive(:perform_later)
         .with(hash_including(parsed_body))
 
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json',
-        'x-contentful-topic': 'ContentManagement.Entry.unpublish'
-      )
-
       # act
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers
 
       # assert
       expect(events.length).to eq(2)
@@ -174,14 +151,10 @@ RSpec.describe WCC::Contentful::WebhookController, type: :request do
       expect(WCC::Contentful.configuration).to receive(:webhook_jobs)
         .and_return(jobs)
 
-      request.headers.merge!(
-        'Authorization': basic_auth('tester1', 'password1'),
-        'Content-Type': 'application/vnd.contentful.management.v1+json',
-        'x-contentful-topic': 'ContentManagement.Entry.unpublish'
-      )
-
       # act
-      post '/wcc/contentful/webhook/receive', body
+      post '/wcc/contentful/webhook/receive',
+        params: body,
+        headers: good_headers
 
       # assert
       expect(events.length).to eq(1)


### PR DESCRIPTION
https://guides.rubyonrails.org/engines.html#routes

If you look at the engines docs for rails, the recommended implementation for an engine is to specify `isolate_namespace SomeEngineName`. There is a subtlety that requires you to specify `main_app.url_helper_x` in any view or partial that is rendered by engine machinery... we felt as if the gem should handle the heavy lifting and not require the client application to know that the engine has such nuances. This requires you to specify the namespace in places like routes, controller references, view paths, etc -- in the gem. See subtle paragraph that took some time to find(from the doc above):

> If a template rendered from within an engine attempts to use one of the application’s routing helper methods, it may result in an undefined method call. If you encounter such an issue, ensure that you’re not attempting to call the application’s routing methods without the main_app prefix from within the engine.