### PR TITLE
Contact form fix

### DIFF
--- a/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/contact-form.js
+++ b/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/contact-form.js
@@ -3,26 +3,15 @@ if (typeof window.$ == 'undefined' ) {
 }
 
 $(function() {
-  console.log('window loaded')
   function handleResponse($form, event, status, xhr) {
-    console.log('in the handleResponse function')
     // Handle backwards compat for [rails/jquery]-ujs ajax callbacks
     var json
     if (event.detail) {
-      console.log('the event detail')
-      console.log(event.detail)
       json = JSON.parse(event.detail[2].response)
       status = event.detail[1]
-      console.log('and the json')
-      console.log(json)
     } else {
       json = xhr.responseJSON
-      console.log('NO event detail')
-      console.log(json)
     }
-
-    console.log('the status is:')
-    console.log(status)
 
     if (status == 'OK') {
       $form.append(
@@ -35,16 +24,13 @@ $(function() {
   }
 
   $('[data-contact-form]').each(function(_, input) {
-    console.log('data-contact-form.each')
     var $form = $(input)
 
     $form.on('ajax:success', function(event, data, status, xhr) {
-      console.log('ajax:success')
       handleResponse($form, event, status, xhr)
     })
 
     $form.on('ajax:error', function(event, xhr, status) {
-      console.log('ajax:error')
       handleResponse($form, event, status, xhr)
     })
   })

--- a/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/contact-form.js
+++ b/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/contact-form.js
@@ -13,7 +13,7 @@ $(function() {
       json = xhr.responseJSON
     }
 
-    if (status == 'OK') {
+    if (status == 'OK' || status == 'success') {
       $form.append(
         $('<span>').text(json.message).delay(2000).fadeOut(2000, function() { $(this).remove() })
       )

--- a/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/contact-form.js
+++ b/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/contact-form.js
@@ -3,15 +3,26 @@ if (typeof window.$ == 'undefined' ) {
 }
 
 $(function() {
+  console.log('window loaded')
   function handleResponse($form, event, status, xhr) {
+    console.log('in the handleResponse function')
     // Handle backwards compat for [rails/jquery]-ujs ajax callbacks
     var json
     if (event.detail) {
+      console.log('the event detail')
+      console.log(event.detail)
       json = JSON.parse(event.detail[2].response)
       status = event.detail[1]
+      console.log('and the json')
+      console.log(json)
     } else {
       json = xhr.responseJSON
+      console.log('NO event detail')
+      console.log(json)
     }
+
+    console.log('the status is:')
+    console.log(status)
 
     if (status == 'OK') {
       $form.append(
@@ -24,13 +35,16 @@ $(function() {
   }
 
   $('[data-contact-form]').each(function(_, input) {
+    console.log('data-contact-form.each')
     var $form = $(input)
 
     $form.on('ajax:success', function(event, data, status, xhr) {
+      console.log('ajax:success')
       handleResponse($form, event, status, xhr)
     })
 
     $form.on('ajax:error', function(event, xhr, status) {
+      console.log('ajax:error')
       handleResponse($form, event, status, xhr)
     })
   })

--- a/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/index.js
+++ b/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/index.js
@@ -1,2 +1,1 @@
 //= require_tree .
-console.log('first things first')

--- a/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/index.js
+++ b/wcc-contentful-app/app/assets/javascripts/wcc/contentful/app/index.js
@@ -1,1 +1,2 @@
 //= require_tree .
+console.log('first things first')

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -32,7 +32,7 @@ module WCC::Contentful::App::SectionHelper
 
   def markdown(text)
     return unless text
-    
+
     markdown_links = links_within_markdown(text)
     links_with_classes, raw_classes = gather_links_with_classes_data(markdown_links)
 

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -31,6 +31,8 @@ module WCC::Contentful::App::SectionHelper
   end
 
   def markdown(text)
+    return unless text
+    
     markdown_links = links_within_markdown(text)
     links_with_classes, raw_classes = gather_links_with_classes_data(markdown_links)
 

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -31,7 +31,7 @@ module WCC::Contentful::App::SectionHelper
   end
 
   def markdown(text)
-    return unless text
+    raise ArgumentError, 'markdown method requires text' unless text
 
     markdown_links = links_within_markdown(text)
     links_with_classes, raw_classes = gather_links_with_classes_data(markdown_links)

--- a/wcc-contentful-app/app/models/wcc/contentful/app/contact_form_submission.rb
+++ b/wcc-contentful-app/app/models/wcc/contentful/app/contact_form_submission.rb
@@ -3,6 +3,7 @@
 module WCC::Contentful::App
   if defined?(::ActiveRecord)
     class ContactFormSubmission < ::ActiveRecord::Base
+      self.table_name = 'wcc_contentful_app_contact_form_submissions'
     end
   end
 end

--- a/wcc-contentful-app/app/views/sections/_contact_form.html.erb
+++ b/wcc-contentful-app/app/views/sections/_contact_form.html.erb
@@ -5,7 +5,7 @@
     </div><!--contact-panel__header-->
 
     <div class="contact-panel__form">
-      <%= form_tag wcc_contentful_app.contact_form_path, remote: true, data: { contact_form: true }, method: 'post' do %>
+      <%= form_tag wcc_contentful_app_engine.contact_form_path, remote: true, data: { contact_form: true }, method: 'post' do %>
         <input type="hidden" name="id" value="<%= section.id %>" />
 
         <% section.fields&.each do |field| %>

--- a/wcc-contentful-app/app/views/sections/_contact_form.html.erb
+++ b/wcc-contentful-app/app/views/sections/_contact_form.html.erb
@@ -5,7 +5,10 @@
     </div><!--contact-panel__header-->
 
     <div class="contact-panel__form">
-      <%= form_tag wcc_contentful_app_engine.contact_form_path, remote: true, data: { contact_form: true }, method: 'post' do %>
+      <%= form_tag wcc_contentful_app_engine.contact_form_path,
+            remote: true,
+            data: { contact_form: true },
+            method: 'post' do %>
         <input type="hidden" name="id" value="<%= section.id %>" />
 
         <% section.fields&.each do |field| %>

--- a/wcc-contentful-app/app/views/sections/_contact_form.html.erb
+++ b/wcc-contentful-app/app/views/sections/_contact_form.html.erb
@@ -5,7 +5,7 @@
     </div><!--contact-panel__header-->
 
     <div class="contact-panel__form">
-      <%= form_tag contact_form_path, remote: true, data: { contact_form: true }, method: 'post' do %>
+      <%= form_tag wcc_contentful_app.contact_form_path, remote: true, data: { contact_form: true }, method: 'post' do %>
         <input type="hidden" name="id" value="<%= section.id %>" />
 
         <% section.fields&.each do |field| %>

--- a/wcc-contentful-app/spec/dummy/db/contentful-schema.json
+++ b/wcc-contentful-app/spec/dummy/db/contentful-schema.json
@@ -57,9 +57,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -69,9 +67,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -81,9 +77,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -127,9 +121,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -156,9 +148,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -214,9 +204,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -226,9 +214,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -304,9 +290,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -333,9 +317,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -402,9 +384,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -414,9 +394,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -437,9 +415,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -529,9 +505,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -541,9 +515,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -553,9 +525,7 @@
           "type": "Integer",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -565,9 +535,7 @@
           "type": "Number",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -577,9 +545,7 @@
           "type": "Date",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -589,9 +555,7 @@
           "type": "Boolean",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -601,9 +565,7 @@
           "type": "Location",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -666,9 +628,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -678,9 +638,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -736,9 +694,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -748,9 +704,7 @@
           "type": "Date",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -760,9 +714,7 @@
           "type": "Date",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -772,9 +724,7 @@
           "type": "Object",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -830,9 +780,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -842,9 +790,7 @@
           "type": "Array",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -905,9 +851,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -917,9 +861,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -940,9 +882,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -953,9 +893,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -979,9 +917,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -1038,9 +974,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1168,9 +1102,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1180,16 +1112,12 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
             "type": "Link",
-            "validations": [
-
-            ],
+            "validations": [],
             "linkType": "Entry"
           }
         },
@@ -1199,9 +1127,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -1289,16 +1215,12 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
             "type": "Symbol",
-            "validations": [
-
-            ]
+            "validations": []
           }
         },
         {
@@ -1307,16 +1229,12 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
             "type": "Symbol",
-            "validations": [
-
-            ]
+            "validations": []
           }
         }
       ]
@@ -1371,9 +1289,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1403,9 +1319,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1429,9 +1343,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1529,9 +1441,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -1595,9 +1505,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -1607,9 +1515,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1637,9 +1543,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1665,9 +1569,7 @@
           "type": "Array",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1688,9 +1590,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1700,9 +1600,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -1765,9 +1663,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -1777,9 +1673,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1789,9 +1683,7 @@
           "type": "Array",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1836,9 +1728,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2168,9 +2058,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -2233,9 +2121,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2245,9 +2131,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -2310,9 +2194,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2322,9 +2204,7 @@
           "type": "Integer",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2334,9 +2214,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2346,9 +2224,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -2440,9 +2316,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2484,9 +2358,7 @@
           "type": "Text",
           "localized": true,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -2549,9 +2421,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2578,9 +2448,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2597,6 +2465,128 @@
                 "default",
                 "gray"
               ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "hw5pse7y1ojx"
+          }
+        },
+        "id": "section-contact-form",
+        "type": "ContentType",
+        "createdAt": "2018-11-05T22:16:04.824Z",
+        "updatedAt": "2018-11-05T22:16:05.218Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2SGEbzNLW9vNhYefhYrx1w"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2SGEbzNLW9vNhYefhYrx1w"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2SGEbzNLW9vNhYefhYrx1w"
+          }
+        },
+        "publishedVersion": 1,
+        "firstPublishedAt": "2018-11-05T22:16:05.218Z",
+        "publishedAt": "2018-11-05T22:16:05.218Z"
+      },
+      "name": "Section: Contact Form",
+      "description": "A Contact Form section contains a Form with several Form Fields.  The responses to the form will be collected and provided to the appropriate administrator.",
+      "displayField": "internalTitle",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "text",
+          "name": "Text",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "fields",
+          "name": "Fields",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "formField"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "submitButtonText",
+          "name": "Submit Button Text",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "notificationEmail",
+          "name": "NotificationEmail",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "regexp": {
+                "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
+                "flags": null
+              },
+              "message": "Must be a valid email address."
             }
           ],
           "disabled": false,
@@ -2661,9 +2651,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2690,9 +2678,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2718,9 +2704,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -3045,9 +3029,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"

--- a/wcc-contentful-app/spec/fixtures/contentful/content_types_mgmt_api.json
+++ b/wcc-contentful-app/spec/fixtures/contentful/content_types_mgmt_api.json
@@ -63,9 +63,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -75,9 +73,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -87,9 +83,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -133,9 +127,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -162,9 +154,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -220,9 +210,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -232,9 +220,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -310,9 +296,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -339,9 +323,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -408,9 +390,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -420,9 +400,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -443,9 +421,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -535,9 +511,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -547,9 +521,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -559,9 +531,7 @@
           "type": "Integer",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -571,9 +541,7 @@
           "type": "Number",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -583,9 +551,7 @@
           "type": "Date",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -595,9 +561,7 @@
           "type": "Boolean",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -607,9 +571,7 @@
           "type": "Location",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -672,9 +634,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -684,9 +644,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -742,9 +700,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -754,9 +710,7 @@
           "type": "Date",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -766,9 +720,7 @@
           "type": "Date",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -778,9 +730,7 @@
           "type": "Object",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -836,9 +786,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -848,9 +796,7 @@
           "type": "Array",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -911,9 +857,7 @@
           "type": "Text",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -923,9 +867,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -946,9 +888,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -959,9 +899,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -985,9 +923,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -1044,9 +980,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1174,9 +1108,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1186,16 +1118,12 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
             "type": "Link",
-            "validations": [
-
-            ],
+            "validations": [],
             "linkType": "Entry"
           }
         },
@@ -1205,9 +1133,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
@@ -1295,16 +1221,12 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
             "type": "Symbol",
-            "validations": [
-
-            ]
+            "validations": []
           }
         },
         {
@@ -1313,16 +1235,12 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
             "type": "Symbol",
-            "validations": [
-
-            ]
+            "validations": []
           }
         }
       ]
@@ -1377,9 +1295,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1409,9 +1325,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1435,9 +1349,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1535,12 +1447,132 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "hw5pse7y1ojx"
+          }
+        },
+        "id": "section-contact-form",
+        "type": "ContentType",
+        "createdAt": "2018-11-05T22:16:04.824Z",
+        "updatedAt": "2018-11-05T22:16:05.218Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2SGEbzNLW9vNhYefhYrx1w"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2SGEbzNLW9vNhYefhYrx1w"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2SGEbzNLW9vNhYefhYrx1w"
+          }
+        },
+        "publishedVersion": 1,
+        "firstPublishedAt": "2018-11-05T22:16:05.218Z",
+        "publishedAt": "2018-11-05T22:16:05.218Z"
+      },
+      "name": "Section: Contact Form",
+      "description": "A Contact Form section contains a Form with several Form Fields.  The responses to the form will be collected and provided to the appropriate administrator.",
+      "displayField": "internalTitle",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "text",
+          "name": "Text",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "fields",
+          "name": "Fields",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "formField"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "submitButtonText",
+          "name": "Submit Button Text",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "notificationEmail",
+          "name": "NotificationEmail",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "regexp": {
+                "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
+                "flags": null
+              },
+              "message": "Must be a valid email address."
+            }
+          ],
+          "disabled": false,
+          "omitted": false
         }
       ]
     },
@@ -1601,9 +1633,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -1613,9 +1643,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1643,9 +1671,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1671,9 +1697,7 @@
           "type": "Array",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1694,9 +1718,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1706,9 +1728,7 @@
           "type": "Symbol",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -1771,9 +1791,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -1783,9 +1801,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -1795,9 +1811,7 @@
           "type": "Array",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -1842,9 +1856,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2174,9 +2186,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -2239,9 +2249,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2251,9 +2259,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -2316,9 +2322,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2328,9 +2332,7 @@
           "type": "Integer",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2340,9 +2342,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2352,9 +2352,7 @@
           "type": "Array",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "items": {
@@ -2446,9 +2444,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2490,9 +2486,7 @@
           "type": "Text",
           "localized": true,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -2555,9 +2549,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2584,9 +2576,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2667,9 +2657,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": true
         },
@@ -2696,9 +2684,7 @@
           "type": "Symbol",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -2724,9 +2710,7 @@
           "type": "Text",
           "localized": false,
           "required": true,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         }
@@ -3051,9 +3035,7 @@
           "type": "Link",
           "localized": false,
           "required": false,
-          "validations": [
-
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"

--- a/wcc-contentful-app/spec/views/sections/_contact_form.html.erb_spec.rb
+++ b/wcc-contentful-app/spec/views/sections/_contact_form.html.erb_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe 'sections/contact_form' do
   helper WCC::Contentful::App::SectionHelper
 
-  it 'renders the given section with empty styles' do
+  it 'raises action view template error if text is nil' do
     section = contentful_create('section-contact-form')
 
-    render partial: 'components/section', locals: { section: section }
-
-    expect(rendered).to have_css('section.section-contact-form.default')
+    expect {
+      render partial: 'components/section', locals: { section: section }
+    }.to raise_error(ActionView::Template::Error)
   end
 
   it 'processes the markdown in the section' do

--- a/wcc-contentful-app/spec/views/sections/_contact_form.html.erb_spec.rb
+++ b/wcc-contentful-app/spec/views/sections/_contact_form.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'sections/contact_form' do
+  helper WCC::Contentful::App::SectionHelper
+
+  it 'renders the given section with empty styles' do
+    section = contentful_create('section-contact-form')
+
+    render partial: 'components/section', locals: { section: section }
+
+    expect(rendered).to have_css('section.section-contact-form.default')
+  end
+
+  it 'processes the markdown in the section' do
+    section = contentful_create('section-contact-form',
+      text: '## This should be an H2')
+
+    render partial: 'components/section', locals: { section: section }
+
+    expect(rendered).to match(/<h2>This should be an H2<\/h2>/)
+  end
+end

--- a/wcc-contentful-app/spec/views/sections/_contact_form.html.erb_spec.rb
+++ b/wcc-contentful-app/spec/views/sections/_contact_form.html.erb_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe 'sections/contact_form' do
   helper WCC::Contentful::App::SectionHelper
 
   it 'raises action view template error if text is nil' do
-    section = contentful_create('section-contact-form')
+    section = contentful_create('section-contact-form',
+      text: nil)
 
     expect {
       render partial: 'components/section', locals: { section: section }

--- a/wcc-contentful/lib/wcc/contentful/downloads_schema.rb
+++ b/wcc-contentful/lib/wcc/contentful/downloads_schema.rb
@@ -10,6 +10,7 @@ class WCC::Contentful::DownloadsSchema
   def initialize(file = nil, management_client: nil)
     @client = management_client || WCC::Contentful::Services.instance.management_client
     @file = file || WCC::Contentful.configuration&.schema_file
+    raise ArgumentError, 'Please configure your management token' unless @client
     raise ArgumentError, 'Please pass filename or call WCC::Contentful.configure' unless @file
   end
 


### PR DESCRIPTION
- Prepend the `contact_form_path` helper method with `wcc_contentful_app_engine` so that the main app doesn't get confused with which routes file to look this up, and instead will know that it belongs to wcc_contentful_app.
- If status isn't `OK` check if it's `success` also
- Explicitly set the table_name for ContactFormSubmission to be 'wcc_contentful_app_contact_form_submissions'
- Short circuit the markdown helper method if the text parameter received is nil
- Add section-contact-form table to the contentful json schema definition
- Raise ArgumentError in downloads_schema that prompts the user to configure their contentful management token unless @client 
- Add spec for section-contact-form