### PR TITLE
146 markdown button fix

### DIFF
--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -56,9 +56,9 @@ module WCC::Contentful::App::SectionHelper
     markdown = ::Redcarpet::Markdown.new(renderer, extensions)
 
     content_tag(:div,
-      markdown.render(
-        remove_markdown_href_class_syntax(raw_classes, text)
-      ).html_safe,
+      CGI.unescapeHTML(markdown.render(
+                         remove_markdown_href_class_syntax(raw_classes, text)
+                       )).html_safe,
       class: 'formatted-content')
   end
 

--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -53,11 +53,12 @@ module WCC::Contentful::App::SectionHelper
     }
 
     renderer = ::WCC::Contentful::App::CustomMarkdownRender.new(options)
-    remove_markdown_href_class_syntax(raw_classes, text)
     markdown = ::Redcarpet::Markdown.new(renderer, extensions)
 
     content_tag(:div,
-      markdown.render(text).html_safe,
+      markdown.render(
+        remove_markdown_href_class_syntax(raw_classes, text)
+      ).html_safe,
       class: 'formatted-content')
   end
 
@@ -85,7 +86,9 @@ module WCC::Contentful::App::SectionHelper
   end
 
   def remove_markdown_href_class_syntax(raw_classes, text)
-    raw_classes.each { |klass| text.slice!(klass) }
+    text_without_markdown_class_syntax = text.dup
+    raw_classes.each { |klass| text_without_markdown_class_syntax.slice!(klass) }
+    text_without_markdown_class_syntax
   end
 
   def url_and_title(markdown_link_and_title)

--- a/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
+++ b/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
@@ -23,11 +23,23 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
     'nothin to see here'
   }
 
+  let(:markdown_link_with_quote) {
+    "[Children's](https://watermark.formstack.com/forms/childrensvolunteer)"
+  }
+
   describe '#markdown' do
     it 'returns string wrapped in div' do
       rendered_html = helper.markdown(markdown_string_without_links)
 
       expect(rendered_html).to have_selector('div.formatted-content')
+    end
+
+    context 'when markdown link text has a single quote in it' do
+      it 'renders the quote as a part of the link text' do
+        html_to_render = helper.markdown(markdown_link_with_quote)
+
+        expect(html_to_render).to have_content("Children's")
+      end
     end
 
     context 'when markdown includes links with classes' do

--- a/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
+++ b/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
     context 'When class doesn\'t begin with a space: [forget spaces](http://www.google.com){:.test}' do
       it 'should still apply the classes to the hyperlink' do
         markdown_string =
-          +'some before text [forget spaces](http://www.google.com){:.test} and some after text'
+          'some before text [forget spaces](http://www.google.com){:.test} and some after text'
         html_to_render =
           helper.markdown(markdown_string)
 
@@ -182,7 +182,7 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
     context 'When classes have no space: [no space](http://www.google.com){: .btn.btn-primary }' do
       it 'should still apply the classes to the hyperlink' do
         markdown_string =
-          +'some before text [no space](http://www.google.com){: .btn.btn-primary } and some after text'
+          'some before text [no space](http://www.google.com){: .btn.btn-primary } and some after text'
         html_to_render =
           helper.markdown(markdown_string)
 
@@ -193,8 +193,11 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
     context 'when content of link matches the class name given' do
       it 'should apply the the class to the hyperlink with no conflict' do
         markdown_string =
-          +'some before text [text or .text that matches a class]'\
-          '(/home "text or .text"){: .text } and some after text'
+          <<-STRING
+            some before text 
+            [text or .text that matches a class](/home "text or .text"){: .text } 
+            and some after text
+          STRING
         html_to_render =
           helper.markdown(markdown_string)
 
@@ -359,14 +362,18 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
           '{: .button-medium .green}'
         ]
       text =
-        +"Ministry developed by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white}"\
-        ' [Watermark Community Church](http://www.watermark.org){: .button-medium .green}'\
-        ' [Test](https://test.com).'
+        <<-STRING
+          Ministry developed by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white}
+           [Watermark Community Church](http://www.watermark.org){: .button-medium .green}
+           [Test](https://test.com).
+        STRING
 
       text_without_class_syntax =
-        +"Ministry developed by [Awaken](/awaken \"Awaken's Homepage\")"\
-        ' [Watermark Community Church](http://www.watermark.org)'\
-        ' [Test](https://test.com).'
+        <<-STRING
+          Ministry developed by [Awaken](/awaken \"Awaken's Homepage\")
+           [Watermark Community Church](http://www.watermark.org)
+           [Test](https://test.com).
+        STRING
 
       expect(text.include?('{: .button .white}')).to be true
 

--- a/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
+++ b/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
@@ -4,15 +4,19 @@ require 'rails_helper'
 
 RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
   let(:markdown_string_with_links_that_have_classes) {
-    +"Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas."\
-    ' Just relax. [Watermark Community Church](http://www.watermark.org){: .button-medium .green} ok.'\
-    ' Last line goes here [Test](https://test.com).'
+    <<-STRING
+      Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas.
+      Just relax. [Watermark Community Church](http://www.watermark.org){: .button-medium .green} ok.
+      Last line goes here [Test](https://test.com).
+    STRING
   }
 
   let(:markdown_string_with_links_that_have_classes2) {
-    +"Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas."\
-    " Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas."\
-    " Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas."
+    <<-STRING
+      Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas.
+      Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas.
+      Ministry by [Awaken](/awaken \"Awaken's Homepage\"){: .button .white} in Dallas, Texas.
+    STRING
   }
 
   let(:markdown_string_with_classless_link) {

--- a/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
+++ b/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
@@ -194,8 +194,8 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
       it 'should apply the the class to the hyperlink with no conflict' do
         markdown_string =
           <<-STRING
-            some before text 
-            [text or .text that matches a class](/home "text or .text"){: .text } 
+            some before text
+            [text or .text that matches a class](/home "text or .text"){: .text }
             and some after text
           STRING
         html_to_render =

--- a/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
+++ b/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
@@ -375,11 +375,11 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
            [Test](https://test.com).
         STRING
 
-      expect(text.include?('{: .button .white}')).to be true
+      expect(text).to include('{: .button .white}')
 
       transformed_text = helper.remove_markdown_href_class_syntax(raw_classes, text)
 
-      expect(transformed_text.include?('{: .button .white}')).to be false
+      expect(transformed_text).to_not include('{: .button .white}')
       expect(transformed_text).to eq(text_without_class_syntax)
     end
   end


### PR DESCRIPTION
- Render actual quotes in link text, rather than some jumbled up code that represents a quote
- Allow us to use multiple links in our markdown that have classes that are all the same, and will all be rendered as html as you would expect

closes #146 