### PR TITLE
271 email improvement

### DIFF
--- a/wcc-contentful-app/app/controllers/wcc/contentful/app/contact_form_controller.rb
+++ b/wcc-contentful-app/app/controllers/wcc/contentful/app/contact_form_controller.rb
@@ -3,7 +3,14 @@
 class WCC::Contentful::App::ContactFormController < ApplicationController
   def create
     address = params[:email_object_id] ? email_address(email_model) : form_model.notification_email
-    form_model.send_email(form_params.merge!({ notification_email: address }))
+    form_model.send_email(
+      form_params.merge!(
+        {
+          notification_email: address,
+          internal_title: params[:internal_title]
+        }
+      )
+    )
 
     render json: { type: 'success', message: "Thanks for reaching out. We'll be in touch soon!" }
   end

--- a/wcc-contentful-app/app/mailers/wcc/contentful/app/contact_mailer.rb
+++ b/wcc-contentful-app/app/mailers/wcc/contentful/app/contact_mailer.rb
@@ -5,7 +5,7 @@ module WCC::Contentful::App
     def contact_form_email(to_email, data)
       @form_data = data
 
-      mail(to: to_email, subject: "#{@form_data[:internal_title]} Submission")
+      mail(from: @form_data[:Email] , to: to_email, subject: "#{@form_data[:internal_title]} Submission")
     end
   end
 end

--- a/wcc-contentful-app/app/mailers/wcc/contentful/app/contact_mailer.rb
+++ b/wcc-contentful-app/app/mailers/wcc/contentful/app/contact_mailer.rb
@@ -5,7 +5,7 @@ module WCC::Contentful::App
     def contact_form_email(to_email, data)
       @form_data = data
 
-      mail(to: to_email, subject: 'Contact Us Form Submission')
+      mail(to: to_email, subject: "#{@form_data[:internal_title]} Submission")
     end
   end
 end

--- a/wcc-contentful-app/app/mailers/wcc/contentful/app/contact_mailer.rb
+++ b/wcc-contentful-app/app/mailers/wcc/contentful/app/contact_mailer.rb
@@ -5,7 +5,7 @@ module WCC::Contentful::App
     def contact_form_email(to_email, data)
       @form_data = data
 
-      mail(from: @form_data[:Email] , to: to_email, subject: "#{@form_data[:internal_title]} Submission")
+      mail(from: @form_data[:Email], to: to_email, subject: "#{@form_data[:internal_title]} Submission")
     end
   end
 end

--- a/wcc-contentful-app/app/views/sections/_contact_form.html.erb
+++ b/wcc-contentful-app/app/views/sections/_contact_form.html.erb
@@ -10,6 +10,7 @@
             data: { contact_form: true },
             method: 'post' do %>
         <input type="hidden" name="id" value="<%= section.id %>" />
+        <input type="hidden" name="internal_title" value="<%= section.internal_title %>" />
         <% if defined?(email_object_id) %>
           <input
             id="email-object-id"

--- a/wcc-contentful-app/app/views/sections/_contact_form.html.erb
+++ b/wcc-contentful-app/app/views/sections/_contact_form.html.erb
@@ -10,7 +10,7 @@
             data: { contact_form: true },
             method: 'post' do %>
         <input type="hidden" name="id" value="<%= section.id %>" />
-        <input type="hidden" name="internal_title" value="<%= section.internal_title %>" />
+        <input id="internal-title" type="hidden" name="internal_title" value="<%= section.internal_title %>" />
         <% if defined?(email_object_id) %>
           <input
             id="email-object-id"

--- a/wcc-contentful-app/app/views/sections/_contact_form.html.erb
+++ b/wcc-contentful-app/app/views/sections/_contact_form.html.erb
@@ -10,7 +10,7 @@
             data: { contact_form: true },
             method: 'post' do %>
         <input type="hidden" name="id" value="<%= section.id %>" />
-        <input id="internal-title" type="hidden" name="internal_title" value="<%= section.internal_title %>" />
+        <%= hidden_field_tag :internal_title, section.internal_title %>
         <% if defined?(email_object_id) %>
           <input
             id="email-object-id"

--- a/wcc-contentful-app/lib/generators/wcc/templates/section-contact-form/migrations/generated_add_section-contact-forms.ts
+++ b/wcc-contentful-app/lib/generators/wcc/templates/section-contact-form/migrations/generated_add_section-contact-forms.ts
@@ -21,7 +21,7 @@ export = function (migration: Migration, { makeRequest, spaceId, accessToken }) 
     required: true,
     validations: [],
     disabled: false,
-    omitted: true
+    omitted: false
   })
 
   sectionContactForm.createField('text', {

--- a/wcc-contentful-app/lib/wcc/contentful/model/section_contact_form.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/model/section_contact_form.rb
@@ -2,13 +2,6 @@
 
 class WCC::Contentful::Model::SectionContactForm < WCC::Contentful::Model
   def send_email(data)
-    puts "WHAT DOES THE DATA LOOK LIKE??"
-    puts "WHAT DOES THE DATA LOOK LIKE??"
-    puts "WHAT DOES THE DATA LOOK LIKE??"
-    puts data.inspect
-    puts "WHAT DOES THE DATA LOOK LIKE??!!!!"
-    puts "WHAT DOES THE DATA LOOK LIKE??!!!!"
-    puts "WHAT DOES THE DATA LOOK LIKE??!!!!"
     ::WCC::Contentful::App::ContactMailer.contact_form_email(data[:notification_email], data).deliver
 
     save_contact_form(data)

--- a/wcc-contentful-app/lib/wcc/contentful/model/section_contact_form.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/model/section_contact_form.rb
@@ -2,6 +2,13 @@
 
 class WCC::Contentful::Model::SectionContactForm < WCC::Contentful::Model
   def send_email(data)
+    puts "WHAT DOES THE DATA LOOK LIKE??"
+    puts "WHAT DOES THE DATA LOOK LIKE??"
+    puts "WHAT DOES THE DATA LOOK LIKE??"
+    puts data.inspect
+    puts "WHAT DOES THE DATA LOOK LIKE??!!!!"
+    puts "WHAT DOES THE DATA LOOK LIKE??!!!!"
+    puts "WHAT DOES THE DATA LOOK LIKE??!!!!"
     ::WCC::Contentful::App::ContactMailer.contact_form_email(data[:notification_email], data).deliver
 
     save_contact_form(data)

--- a/wcc-contentful-app/spec/dummy/db/contentful-schema.json
+++ b/wcc-contentful-app/spec/dummy/db/contentful-schema.json
@@ -2531,7 +2531,7 @@
           "required": true,
           "validations": [],
           "disabled": false,
-          "omitted": true
+          "omitted": false
         },
         {
           "id": "text",

--- a/wcc-contentful-app/spec/fixtures/contentful/content_types_mgmt_api.json
+++ b/wcc-contentful-app/spec/fixtures/contentful/content_types_mgmt_api.json
@@ -1513,7 +1513,7 @@
           "required": true,
           "validations": [],
           "disabled": false,
-          "omitted": true
+          "omitted": false
         },
         {
           "id": "text",


### PR DESCRIPTION
- Omit the internal title for section-contact-form
- Interpolate the section-contact-form internal title into the subject line of the email that gets sent for each contact-form submission
- Override the default 'from' email address used for contact-form submissions. Now the 'from' email address will be whichever email address that was submitted into the email field of the contact-form
- Store the internal title as a hidden field within the contact form

neccessary for watermarkchurch/paper-signs#271