### PR TITLE
Fix markdown link parsing

### DIFF
--- a/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
+++ b/wcc-contentful-app/app/helpers/wcc/contentful/app/section_helper.rb
@@ -60,10 +60,6 @@ module WCC::Contentful::App::SectionHelper
     markdown = ::Redcarpet::Markdown.new(renderer, extensions)
     html_to_render = markdown.render(remove_markdown_href_class_syntax(raw_classes, text))
 
-    if match = hyperlink_match(html_to_render)
-      html_to_render = remove_target_blank(html_to_render) unless use_target_blank?(match[1])
-    end
-
     content_tag(:div,
       CGI.unescapeHTML(html_to_render).html_safe,
       class: 'formatted-content')
@@ -118,22 +114,6 @@ module WCC::Contentful::App::SectionHelper
       class_string += klass.tr('.', '') + ' '
     end
     class_string
-  end
-
-  def hyperlink_match(string)
-    # return MatchData hash if string includes a hyperlink
-    /href\s*=\s*"([^"]*)"/.match(string)
-  end
-
-  def use_target_blank?(url)
-    return false unless scheme = URI.parse(url).scheme
-    return false unless scheme != 'mailto'
-
-    true
-  end
-
-  def remove_target_blank(string)
-    string.gsub('target="_blank"', '')
   end
 
   def safe_line_break(text)

--- a/wcc-contentful-app/app/models/wcc/contentful/app/custom_markdown_render.rb
+++ b/wcc-contentful-app/app/models/wcc/contentful/app/custom_markdown_render.rb
@@ -33,10 +33,7 @@ module WCC::Contentful::App
     end
 
     def use_target_blank?(url)
-      return false unless scheme = URI.parse(url).scheme
-      return false if scheme == 'mailto'
-
-      true
+      url.scan(/(\s|^)(https?:\/\/\S*)/).present?
     end
   end
 end

--- a/wcc-contentful-app/app/models/wcc/contentful/app/custom_markdown_render.rb
+++ b/wcc-contentful-app/app/models/wcc/contentful/app/custom_markdown_render.rb
@@ -25,7 +25,7 @@ module WCC::Contentful::App
     def hyperlink_attributes(title, url, link_class = nil)
       link_attrs = { title: title, class: link_class }
 
-      link_attrs[:target] = '_blank' if use_target_blank?(url)
+      link_attrs[:target] = use_target_blank?(url) ? '_blank' : nil
 
       return link_attrs unless @options[:link_attributes]
 
@@ -33,7 +33,10 @@ module WCC::Contentful::App
     end
 
     def use_target_blank?(url)
-      url.scan(/(\s|^)(https?:\/\/\S*)/).present?
+      return false unless scheme = URI.parse(url).scheme
+      return false if scheme == 'mailto'
+
+      true
     end
   end
 end

--- a/wcc-contentful-app/spec/models/wcc/contentful/app/custom_markdown_render_spec.rb
+++ b/wcc-contentful-app/spec/models/wcc/contentful/app/custom_markdown_render_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe WCC::Contentful::App::CustomMarkdownRender, type: :model do
     let(:link_class) {
       'button white '
     }
+    let(:relative_link) {
+      '/some-page'
+    }
 
     it 'does not raise exception if link_attributes is nil' do
       options = {
@@ -41,6 +44,19 @@ RSpec.describe WCC::Contentful::App::CustomMarkdownRender, type: :model do
 
       renderer = WCC::Contentful::App::CustomMarkdownRender.new(options)
       expect(renderer.link(link, title, content)).to include('target="_blank"')
+    end
+
+    it 'respects relative links even when target blank is preferred' do
+      options = {
+        filter_html: true,
+        hard_wrap: true,
+        link_attributes: { target: '_blank' },
+        space_after_headers: true,
+        fenced_code_blocks: true
+      }
+
+      renderer = WCC::Contentful::App::CustomMarkdownRender.new(options)
+      expect(renderer.link(relative_link, title, content)).to_not include('target="_blank"')
     end
 
     context 'when link has a class' do
@@ -125,9 +141,10 @@ RSpec.describe WCC::Contentful::App::CustomMarkdownRender, type: :model do
       end
     end
   end
+
   describe '#use_target_blank?' do
     context 'when given a relative url' do
-      it 'returns nil' do
+      it 'returns false' do
         url = '/awaken'
         options = {
           filter_html: true,
@@ -144,7 +161,7 @@ RSpec.describe WCC::Contentful::App::CustomMarkdownRender, type: :model do
     end
 
     context 'when given a hash location as url' do
-      it 'returns nil' do
+      it 'returns false' do
         url = '#awaken'
         options = {
           filter_html: true,
@@ -161,7 +178,7 @@ RSpec.describe WCC::Contentful::App::CustomMarkdownRender, type: :model do
     end
 
     context 'when given an absolute url' do
-      it 'returns target=_blank' do
+      it 'returns true' do
         url = 'https://www.watermarkresources.com'
         options = {
           filter_html: true,
@@ -174,6 +191,23 @@ RSpec.describe WCC::Contentful::App::CustomMarkdownRender, type: :model do
 
         renderer = WCC::Contentful::App::CustomMarkdownRender.new(options)
         expect(renderer.use_target_blank?(url)).to be true
+      end
+    end
+
+    context 'when given a mailto url' do
+      it 'returns false' do
+        url = 'mailto:students@watermark.org'
+        options = {
+          filter_html: true,
+          hard_wrap: true,
+          link_attributes: { target: '_blank' },
+          space_after_headers: true,
+          fenced_code_blocks: true,
+          links_with_classes: []
+        }
+
+        renderer = WCC::Contentful::App::CustomMarkdownRender.new(options)
+        expect(renderer.use_target_blank?(url)).to be false
       end
     end
   end


### PR DESCRIPTION
re watermarkchurch/paper-signs#354

We were doing double duty on parsing markdown links and their targets... some of the work was conflicting with the other, and we just needed to modify the renderer.