### PR TITLE
154 algolia reindex job environments

### DIFF
--- a/wcc-contentful-app/wcc-contentful-app.gemspec
+++ b/wcc-contentful-app/wcc-contentful-app.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.52'
+  spec.add_development_dependency 'rubocop', '0.66'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'vcr', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.0'

--- a/wcc-contentful/app/controllers/wcc/contentful/webhook_controller.rb
+++ b/wcc-contentful/app/controllers/wcc/contentful/webhook_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require_dependency 'wcc/contentful/application_controller'
-require_dependency 'wcc/contentful/event'
-require 'wisper'
 
 module WCC::Contentful
   # The WebhookController is mounted by the WCC::Contentful::Engine to receive

--- a/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
+++ b/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
@@ -7,7 +7,9 @@ module WCC::Contentful
     self.queue_adapter = :async
     queue_as :default
 
-    def perform(args)
+    def perform(args = {})
+      args = default_configuration.merge!(args)
+
       client = WCC::Contentful::SimpleClient::Management.new(
         args
       )
@@ -42,6 +44,21 @@ module WCC::Contentful
     end
 
     private
+
+    def default_configuration
+      return {} unless config = WCC::Contentful&.configuration
+
+      {
+        management_token: config.management_token,
+        app_url: config.app_url,
+        space: config.space,
+        environment: config.environment,
+        default_locale: config.default_locale,
+        adapter: config.http_adapter,
+        webhook_username: config.webhook_username,
+        webhook_password: config.webhook_password
+      }
+    end
 
     def webhook_filters
       filters = []

--- a/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
+++ b/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
@@ -26,7 +26,8 @@ module WCC::Contentful
         'topics' => [
           '*.publish',
           '*.unpublish'
-        ]
+        ],
+        'filters' => webhook_filters
       }
       body['httpBasicUsername'] = webhook_username if webhook_username.present?
       body['httpBasicPassword'] = webhook_password if webhook_password.present?
@@ -38,6 +39,22 @@ module WCC::Contentful
         logger.error "#{e.response.code}: #{e.response.raw}" if e.response
         raise
       end
+    end
+
+    private
+
+    def webhook_filters
+      filters = []
+
+      if (environment_id = WCC::Contentful.configuration&.environment).present?
+        filters << {
+          'equals' => [
+            { 'doc' => 'sys.environment.sys.id' },
+            environment_id
+          ]
+        }
+      end
+      filters
     end
   end
 end

--- a/wcc-contentful/lib/wcc/contentful/engine.rb
+++ b/wcc-contentful/lib/wcc/contentful/engine.rb
@@ -33,18 +33,7 @@ module WCC::Contentful
       next unless config&.management_token.present?
       next unless config.app_url.present?
 
-      if Rails.env.production?
-        WebhookEnableJob.set(wait: 10.seconds).perform_later(
-          management_token: config.management_token,
-          app_url: config.app_url,
-          space: config.space,
-          environment: config.environment,
-          default_locale: config.default_locale,
-          adapter: config.http_adapter,
-          webhook_username: config.webhook_username,
-          webhook_password: config.webhook_password
-        )
-      end
+      WebhookEnableJob.set(wait: 10.seconds).perform_later if Rails.env.production?
     end
 
     config.generators do |g|

--- a/wcc-contentful/lib/wcc/contentful/indexed_representation.rb
+++ b/wcc-contentful/lib/wcc/contentful/indexed_representation.rb
@@ -29,8 +29,8 @@ module WCC::Contentful
       ret
     end
 
-    def to_json
-      @types.to_json
+    def to_json(*args)
+      @types.to_json(*args)
     end
 
     def deep_dup

--- a/wcc-contentful/spec/fixtures/contentful/contentful_published_page_staging.json
+++ b/wcc-contentful/spec/fixtures/contentful/contentful_published_page_staging.json
@@ -1,0 +1,121 @@
+{
+  "sys": {
+    "type": "Entry",
+    "id": "2LJMdSxlrOkuSUYCoOQy2Y",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "7yx6ovlj39n5"
+      }
+    },
+    "environment": {
+      "sys": {
+        "id": "staging",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "page"
+      }
+    },
+    "revision": 17,
+    "createdAt": "2018-04-18T18:19:46.611Z",
+    "updatedAt": "2019-03-13T19:59:04.548Z"
+  },
+  "fields": {
+    "internalTitle": {
+      "en-US": "Conferences"
+    },
+    "title": {
+      "en-US": "Conferences"
+    },
+    "slug": {
+      "en-US": "/conferences"
+    },
+    "header": {
+      "en-US": {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "68vwBQpGa4Cyse4OUaSAsI"
+        }
+      }
+    },
+    "sections": {
+      "en-US": [
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "5bWVC3tXwWCsqii0kcsgo4"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "17JpHearMacQCiq06iSwEO"
+          }
+        }
+      ]
+    },
+    "subpages": {
+      "en-US": [
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "5DMBXEqWdiGEOo4ICGGK8u"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "1x6xVb6hJeIAiKKMIOCOo6"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "5FsqsbMECsM62e04U8sY4Y"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "WvVdsSRyKq4Mi2mYUCYEu"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "4WSFtXJUZyqqgWco6Oi0yK"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "14zlUV8P36UywEoQQw804m"
+          }
+        },
+        {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "1nSH5Luy6cioukogkC64aG"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
+++ b/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
@@ -120,7 +120,8 @@ RSpec.describe WCC::Contentful::WebhookEnableJob, type: :job do
         expect(client).to be_a WCC::Contentful::SimpleClient::Management
 
         options = client.instance_variable_get('@options')
-        expect(options.except(:adapter)).to eq(defaults.except(:space, :management_token, :http_adapter))
+        expect(options.except(:adapter))
+          .to eq(defaults.except(:space, :management_token, :http_adapter))
         expect(client.space).to eq('testspace')
         expect(client.instance_variable_get('@access_token')).to eq('testtoken')
         expect(options[:adapter]).to eq(:http)

--- a/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
+++ b/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
@@ -60,6 +60,32 @@ RSpec.describe WCC::Contentful::WebhookEnableJob, type: :job do
         webhook_username: 'testuser',
         webhook_password: 'testpw')
     end
+
+    it 'posts with environment ID filter if environment given' do
+      config = double(environment: 'testtest')
+      allow(WCC::Contentful).to receive(:configuration)
+        .and_return(config)
+
+      response = double(items: [])
+      client = double(webhook_definitions: response)
+
+      expect(client).to receive(:post_webhook_definition)
+        .with(hash_including({
+          'filters' => [
+            {
+              'equals' => [
+                { 'doc' => 'sys.environment.sys.id' },
+                'testtest'
+              ]
+            }
+          ]
+        }))
+        .and_return(double(raw: {}))
+
+      # act
+      job.enable_webhook(client,
+        app_url: 'https://test.url/')
+    end
   end
 
   describe '#perform' do

--- a/wcc-contentful/wcc-contentful.gemspec
+++ b/wcc-contentful/wcc-contentful.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.52'
+  spec.add_development_dependency 'rubocop', '0.66'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'vcr', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.0'


### PR DESCRIPTION
* The WebhookController now checks the environment of incoming events against the configured environment, and ignores events for the wrong environment.
* The WebhookEnableJob now applies an Environment filter [as described in the Webhook documentation](https://www.contentful.com/developers/docs/concepts/webhooks/#filters) when the environment is configured