### PR TITLE
middleware hotfix

### DIFF
--- a/wcc-contentful-app/spec/wcc/contentful/app/middleware/publish_at_spec.rb
+++ b/wcc-contentful-app/spec/wcc/contentful/app/middleware/publish_at_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe WCC::Contentful::App::Middleware::PublishAt do
         }
       }
 
-      allow(store).to receive(:find).with('test').and_return(entry)
+      allow(store).to receive(:find).with('test', {}).and_return(entry)
 
       result = instance.find('test')
 
@@ -66,7 +66,7 @@ RSpec.describe WCC::Contentful::App::Middleware::PublishAt do
         }
       }
 
-      allow(store).to receive(:find).with('test').and_return(entry)
+      allow(store).to receive(:find).with('test', {}).and_return(entry)
 
       result = instance.find('test')
 
@@ -84,7 +84,7 @@ RSpec.describe WCC::Contentful::App::Middleware::PublishAt do
         }
       }
 
-      allow(store).to receive(:find).with('test').and_return(entry)
+      allow(store).to receive(:find).with('test', {}).and_return(entry)
 
       result = instance.find('test')
 
@@ -102,7 +102,7 @@ RSpec.describe WCC::Contentful::App::Middleware::PublishAt do
         }
       }
 
-      allow(store).to receive(:find).with('test').and_return(entry)
+      allow(store).to receive(:find).with('test', {}).and_return(entry)
 
       result = instance.find('test')
 
@@ -116,7 +116,7 @@ RSpec.describe WCC::Contentful::App::Middleware::PublishAt do
         }
       }
 
-      allow(store).to receive(:find).with('test').and_return(entry)
+      allow(store).to receive(:find).with('test', {}).and_return(entry)
 
       result = instance.find('test')
 

--- a/wcc-contentful/lib/wcc/contentful/middleware/store.rb
+++ b/wcc-contentful/lib/wcc/contentful/middleware/store.rb
@@ -28,8 +28,8 @@ module WCC::Contentful::Middleware::Store
     end
   end
 
-  def find(id)
-    found = store.find(id)
+  def find(id, **options)
+    found = store.find(id, **options)
     return transform(found) if found && select?(found)
   end
 

--- a/wcc-contentful/spec/wcc/contentful/middleware/store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/middleware/store_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe WCC::Contentful::Middleware::Store do
           }
         }
         expect(next_store).to receive(:find)
-          .with('1234')
+          .with('1234', {})
           .and_return(entry)
 
         # act
@@ -75,13 +75,28 @@ RSpec.describe WCC::Contentful::Middleware::Store do
           }
         }
         expect(next_store).to receive(:find)
-          .with('1234')
+          .with('1234', {})
           .and_return(entry)
 
         # act
         found = instance.find('1234')
 
         expect(found).to be nil
+      end
+
+      it 'passes hint options through' do
+        entry = {
+          'sys' => sys,
+          'fields' => {
+            'exclude' => { 'en-US' => true }
+          }
+        }
+        expect(next_store).to receive(:find)
+          .with('1234', { hint: 'test', option2: 'test2' })
+          .and_return(entry)
+
+        # act
+        found = instance.find('1234', hint: 'test', option2: 'test2')
       end
     end
 
@@ -262,7 +277,7 @@ RSpec.describe WCC::Contentful::Middleware::Store do
           }
         }
         expect(next_store).to receive(:find)
-          .with('1234')
+          .with('1234', {})
           .and_return(entry)
 
         # act

--- a/wcc-contentful/spec/wcc/contentful/middleware/store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/middleware/store_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe WCC::Contentful::Middleware::Store do
           .and_return(entry)
 
         # act
-        found = instance.find('1234', hint: 'test', option2: 'test2')
+        instance.find('1234', hint: 'test', option2: 'test2')
       end
     end
 


### PR DESCRIPTION
  Asset.find() sends { hint: 'Asset' } to the underlying store, this commit ensures we can handle that in the middleware.

<img width="694" alt="image" src="https://user-images.githubusercontent.com/430257/55256260-a319ec80-522a-11e9-9600-bb79a5729bf3.png">
