### PR TITLE
1355 activesupport instrumentation

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/configuration.rb
+++ b/wcc-contentful/lib/wcc/contentful/configuration.rb
@@ -21,6 +21,7 @@ class WCC::Contentful::Configuration
     connection_options
     update_schema_file
     schema_file
+    instrumentation_adapter
   ].freeze
 
   # (required) Sets the Contentful Space ID.
@@ -175,6 +176,11 @@ class WCC::Contentful::Configuration
   def schema_file
     Rails.root.join(@schema_file)
   end
+
+  # Overrides the use of ActiveSupport::Notifications throughout this library to
+  # emit instrumentation events.  The object or module provided here must respond
+  # to :instrument like ActiveSupport::Notifications.instrument
+  attr_accessor :instrumentation_adapter
 
   def initialize
     @access_token = ''

--- a/wcc-contentful/lib/wcc/contentful/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/instrumentation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WCC::Contentful
+  module Instrumentation
+    extend ActiveSupport::Concern
+
+    def instrumentation_event_prefix
+      @instrumentation_event_prefix ||=
+        # WCC::Contentful => contentful.wcc
+        '.' + self.class.name.parameterize.split('-').reverse.join('.')
+    end
+
+    included do
+      private
+
+      def instrument(name, payload = {}, &block)
+        name += instrumentation_event_prefix
+        (@_instrumentation ||= ActiveSupport::Notifications)
+          .instrument(name, payload, &block)
+      end
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/instrumentation.rb
@@ -16,7 +16,7 @@ module WCC::Contentful
 
       def _instrument(name, payload = {}, &block)
         name += _instrumentation_event_prefix
-        (@_instrumentation ||= ActiveSupport::Notifications)
+        (@_instrumentation ||= WCC::Contentful::Services.instance.instrumentation)
           .instrument(name, payload, &block)
       end
     end
@@ -24,7 +24,8 @@ module WCC::Contentful
     class << self
       def instrument(name, payload = {}, &block)
         # TODO: load config
-        ActiveSupport::Notifications.instrument(name, payload, &block)
+        WCC::Contentful::Services.instance
+          .instrumentation.instrument(name, payload, &block)
       end
     end
   end

--- a/wcc-contentful/lib/wcc/contentful/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/instrumentation.rb
@@ -23,7 +23,6 @@ module WCC::Contentful
 
     class << self
       def instrument(name, payload = {}, &block)
-        # TODO: load config
         WCC::Contentful::Services.instance
           .instrumentation.instrument(name, payload, &block)
       end

--- a/wcc-contentful/lib/wcc/contentful/model_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_methods.rb
@@ -5,6 +5,8 @@
 #
 # @api Model
 module WCC::Contentful::ModelMethods
+  include WCC::Contentful::Instrumentation
+
   # The set of options keys that are specific to the Model layer and shouldn't
   # be passed down to the Store layer.
   MODEL_LAYER_CONTEXT_KEYS = %i[
@@ -49,13 +51,16 @@ module WCC::Contentful::ModelMethods
 
     has_unresolved_raw_links = (raw_link_ids - backlinked_ids).any?
     if has_unresolved_raw_links
-      # use include param to do resolution
-      raw = self.class.store(context[:preview])
-        .find_by(content_type: self.class.content_type,
-                 filter: { 'sys.id' => id },
-                 options: context.except(*MODEL_LAYER_CONTEXT_KEYS).merge!({
-                   include: [depth, 10].min
-                 }))
+      raw =
+        _instrument 'resolve', id: id, depth: depth, backlinks: backlinked_ids do
+          # use include param to do resolution
+          self.class.store(context[:preview])
+            .find_by(content_type: self.class.content_type,
+                     filter: { 'sys.id' => id },
+                     options: context.except(*MODEL_LAYER_CONTEXT_KEYS).merge!({
+                       include: [depth, 10].min
+                     }))
+        end
       unless raw
         raise WCC::Contentful::ResolveError, "Cannot find #{self.class.content_type} with ID #{id}"
       end
@@ -128,6 +133,12 @@ module WCC::Contentful::ModelMethods
 
   delegate :to_json, to: :to_h
 
+  protected
+
+  def _instrumentation_event_prefix
+    '.model.contentful.wcc'
+  end
+
   private
 
   def _resolve_field(field_name, depth = 1, context = {}, options = {})
@@ -157,7 +168,9 @@ module WCC::Contentful::ModelMethods
         # instantiate from already resolved raw entry data.
         m = already_resolved ||
           if raw.dig('sys', 'type') == 'Link'
-            WCC::Contentful::Model.find(id, options: new_context)
+            _instrument 'resolve', id: self.id, depth: depth, backlinks: context[:backlinks]&.map(&:id) do
+              WCC::Contentful::Model.find(id, options: new_context)
+            end
           else
             WCC::Contentful::Model.new_from_raw(raw, new_context)
           end

--- a/wcc-contentful/lib/wcc/contentful/model_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_methods.rb
@@ -168,7 +168,8 @@ module WCC::Contentful::ModelMethods
         # instantiate from already resolved raw entry data.
         m = already_resolved ||
           if raw.dig('sys', 'type') == 'Link'
-            _instrument 'resolve', id: self.id, depth: depth, backlinks: context[:backlinks]&.map(&:id) do
+            _instrument 'resolve',
+              id: self.id, depth: depth, backlinks: context[:backlinks]&.map(&:id) do
               WCC::Contentful::Model.find(id, options: new_context)
             end
           else

--- a/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
@@ -12,8 +12,12 @@ module WCC::Contentful::ModelSingletonMethods
   #   WCC::Contentful::Model::Page.find(id)
   def find(id, options: nil)
     options ||= {}
-    raw = store(options[:preview])
-      .find(id, { hint: type }.merge!(options.except(:preview)))
+    store = store(options[:preview])
+    raw =
+      WCC::Contentful::Instrumentation.instrument 'find.model.contentful.wcc',
+        content_type: content_type, id: id, options: options do
+        store.find(id, { hint: type }.merge!(options.except(:preview)))
+      end
     new(raw, options) if raw.present?
   end
 
@@ -30,8 +34,12 @@ module WCC::Contentful::ModelSingletonMethods
 
     filter.transform_keys! { |k| k.to_s.camelize(:lower) } if filter.present?
 
-    query = store(options[:preview])
-      .find_all(content_type: content_type, options: options.except(:preview))
+    store = store(options[:preview])
+    query =
+      WCC::Contentful::Instrumentation.instrument 'find_all.model.contentful.wcc',
+        content_type: content_type, filter: filter, options: options do
+        store.find_all(content_type: content_type, options: options.except(:preview))
+      end
     query = query.apply(filter) if filter.present?
     query.map { |r| new(r, options) }
   end
@@ -48,8 +56,12 @@ module WCC::Contentful::ModelSingletonMethods
 
     filter.transform_keys! { |k| k.to_s.camelize(:lower) } if filter.present?
 
-    result = store(options[:preview])
-      .find_by(content_type: content_type, filter: filter, options: options.except(:preview))
+    store = store(options[:preview])
+    result =
+      WCC::Contentful::Instrumentation.instrument 'find_by.model.contentful.wcc',
+        content_type: content_type, filter: filter, options: options do
+        store.find_by(content_type: content_type, filter: filter, options: options.except(:preview))
+      end
 
     new(result, options) if result
   end

--- a/wcc-contentful/lib/wcc/contentful/services.rb
+++ b/wcc-contentful/lib/wcc/contentful/services.rb
@@ -126,6 +126,13 @@ module WCC::Contentful
         end
     end
 
+    def instrumentation
+      @instrumentation ||=
+        ensure_configured do |config|
+          config.instrumentation_adapter || ActiveSupport::Notifications
+        end
+    end
+
     private
 
     def ensure_configured

--- a/wcc-contentful/lib/wcc/contentful/services.rb
+++ b/wcc-contentful/lib/wcc/contentful/services.rb
@@ -127,10 +127,12 @@ module WCC::Contentful
     end
 
     def instrumentation
+      return @instrumentation if @instrumentation
+      return ActiveSupport::Notifications if WCC::Contentful.configuration.nil?
+
       @instrumentation ||=
-        ensure_configured do |config|
-          config.instrumentation_adapter || ActiveSupport::Notifications
-        end
+        WCC::Contentful.configuration.instrumentation_adapter ||
+        ActiveSupport::Notifications
     end
 
     private

--- a/wcc-contentful/lib/wcc/contentful/simple_client.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client.rb
@@ -142,6 +142,7 @@ module WCC::Contentful
         if resp.status == 429 &&
             reset = resp.headers['X-Contentful-RateLimit-Reset'].presence
           reset = reset.to_f
+          _instrument 'rate_limit', start: start, reset: reset, timeout: @rate_limit_wait_timeout
           now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           if (now - start) + reset < @rate_limit_wait_timeout
             sleep(reset)

--- a/wcc-contentful/lib/wcc/contentful/simple_client.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client.rb
@@ -48,7 +48,7 @@ module WCC::Contentful
       @adapter = SimpleClient.load_adapter(options[:connection])
 
       @options = options
-      @instrumentation = @options[:instrumentation]
+      @_instrumentation = @options[:instrumentation]
       @query_defaults = {}
       @query_defaults[:locale] = @options[:default_locale] if @options[:default_locale]
       # default 1.5 so that we retry one time then fail if still rate limited
@@ -67,7 +67,7 @@ module WCC::Contentful
       url = URI.join(@api_url, path)
 
       resp =
-        instrument 'get_http', url: url, query: query do
+        _instrument 'get_http', url: url, query: query do
           get_http(url, query)
         end
       Response.new(self,
@@ -117,7 +117,7 @@ module WCC::Contentful
 
     private
 
-    def instrumentation_event_prefix
+    def _instrumentation_event_prefix
       # Unify all CDN, Management, Preview notifications under same namespace
       '.simpleclient.contentful.wcc'
     end
@@ -176,7 +176,7 @@ module WCC::Contentful
       # Gets an entry by ID
       def entry(key, query = {})
         resp =
-          instrument 'entries', id: key, type: 'Entry', query: query do
+          _instrument 'entries', id: key, type: 'Entry', query: query do
             get("entries/#{key}", query)
           end
         resp.assert_ok!
@@ -185,7 +185,7 @@ module WCC::Contentful
       # Queries entries with optional query parameters
       def entries(query = {})
         resp =
-          instrument 'entries', type: 'Entry', query: query do
+          _instrument 'entries', type: 'Entry', query: query do
             get('entries', query)
           end
         resp.assert_ok!
@@ -194,7 +194,7 @@ module WCC::Contentful
       # Gets an asset by ID
       def asset(key, query = {})
         resp =
-          instrument 'entries', type: 'Asset', id: key, query: query do
+          _instrument 'entries', type: 'Asset', id: key, query: query do
             get("assets/#{key}", query)
           end
         resp.assert_ok!
@@ -203,7 +203,7 @@ module WCC::Contentful
       # Queries assets with optional query parameters
       def assets(query = {})
         resp =
-          instrument 'entries', type: 'Asset', query: query do
+          _instrument 'entries', type: 'Asset', query: query do
             get('assets', query)
           end
         resp.assert_ok!
@@ -212,7 +212,7 @@ module WCC::Contentful
       # Queries content types with optional query parameters
       def content_types(query = {})
         resp =
-          instrument 'content_types', query: query do
+          _instrument 'content_types', query: query do
             get('content_types', query)
           end
         resp.assert_ok!
@@ -233,7 +233,7 @@ module WCC::Contentful
           end
         query = query.merge(sync_token)
         resp =
-          instrument 'sync', sync_token: sync_token, query: query do
+          _instrument 'sync', sync_token: sync_token, query: query do
             get('sync', query)
           end
         resp = SyncResponse.new(resp)

--- a/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
@@ -19,12 +19,18 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
   end
 
   def content_types(**query)
-    resp = get('content_types', query)
+    resp =
+      instrument 'content_types', query: query do
+        get('content_types', query)
+      end
     resp.assert_ok!
   end
 
   def content_type(key, query = {})
-    resp = get("content_types/#{key}", query)
+    resp =
+      instrument 'content_type', content_type: key, query: query do
+        get("content_types/#{key}", query)
+      end
     resp.assert_ok!
   end
 

--- a/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
@@ -20,7 +20,7 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
 
   def content_types(**query)
     resp =
-      instrument 'content_types', query: query do
+      _instrument 'content_types', query: query do
         get('content_types', query)
       end
     resp.assert_ok!
@@ -28,7 +28,7 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
 
   def content_type(key, query = {})
     resp =
-      instrument 'content_types', content_type: key, query: query do
+      _instrument 'content_types', content_type: key, query: query do
         get("content_types/#{key}", query)
       end
     resp.assert_ok!
@@ -36,7 +36,7 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
 
   def editor_interface(content_type_id, query = {})
     resp =
-      instrument 'editor_interfaces', content_type: content_type_id, query: query do
+      _instrument 'editor_interfaces', content_type: content_type_id, query: query do
         get("content_types/#{content_type_id}/editor_interface", query)
       end
     resp.assert_ok!
@@ -44,7 +44,7 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
 
   def webhook_definitions(**query)
     resp =
-      instrument 'webhook_definitions', query: query do
+      _instrument 'webhook_definitions', query: query do
         get("/spaces/#{space}/webhook_definitions", query)
       end
     resp.assert_ok!
@@ -74,7 +74,7 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
   # }
   def post_webhook_definition(webhook)
     resp =
-      instrument 'post.webhook_definitions' do
+      _instrument 'post.webhook_definitions' do
         post("/spaces/#{space}/webhook_definitions", webhook)
       end
     resp.assert_ok!
@@ -84,7 +84,7 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
     url = URI.join(@api_url, path)
 
     resp =
-      instrument 'post_http', url: url do
+      _instrument 'post_http', url: url do
         post_http(url, body)
       end
 

--- a/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
@@ -28,19 +28,25 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
 
   def content_type(key, query = {})
     resp =
-      instrument 'content_type', content_type: key, query: query do
+      instrument 'content_types', content_type: key, query: query do
         get("content_types/#{key}", query)
       end
     resp.assert_ok!
   end
 
   def editor_interface(content_type_id, query = {})
-    resp = get("content_types/#{content_type_id}/editor_interface", query)
+    resp =
+      instrument 'editor_interfaces', content_type: content_type_id, query: query do
+        get("content_types/#{content_type_id}/editor_interface", query)
+      end
     resp.assert_ok!
   end
 
   def webhook_definitions(**query)
-    resp = get("/spaces/#{space}/webhook_definitions", query)
+    resp =
+      instrument 'webhook_definitions', query: query do
+        get("/spaces/#{space}/webhook_definitions", query)
+      end
     resp.assert_ok!
   end
 
@@ -67,16 +73,24 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
   #   ]
   # }
   def post_webhook_definition(webhook)
-    resp = post("/spaces/#{space}/webhook_definitions", webhook)
+    resp =
+      instrument 'post.webhook_definitions' do
+        post("/spaces/#{space}/webhook_definitions", webhook)
+      end
     resp.assert_ok!
   end
 
   def post(path, body)
     url = URI.join(@api_url, path)
 
+    resp =
+      instrument 'post_http', url: url do
+        post_http(url, body)
+      end
+
     Response.new(self,
       { url: url, body: body },
-      post_http(url, body))
+      resp)
   end
 
   private

--- a/wcc-contentful/lib/wcc/contentful/simple_client/response.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/response.rb
@@ -55,7 +55,7 @@ class WCC::Contentful::SimpleClient
         skip: page_items.length + skip
       })
       np =
-        instrument 'page', url: @request[:url], query: query do
+        _instrument 'page', url: @request[:url], query: query do
           @client.get(@request[:url], query)
         end
       @next_page = np.assert_ok!
@@ -140,7 +140,7 @@ class WCC::Contentful::SimpleClient
 
       url = raw['nextPageUrl']
       next_page =
-        instrument 'page', url: url do
+        _instrument 'page', url: url do
           @client.get(url)
         end
 

--- a/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
@@ -2,6 +2,8 @@
 
 module WCC::Contentful::Store
   class CDNAdapter
+    # Note: CDNAdapter should not instrument store events cause it's not a store.
+
     attr_reader :client
 
     # The CDNAdapter cannot index data coming back from the Sync API.

--- a/wcc-contentful/lib/wcc/contentful/store/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/instrumentation.rb
@@ -20,7 +20,37 @@ module WCC::Contentful::Store
   module InstrumentationWrapper
     def find(key, **options)
       _instrument 'find', id: key, options: options do
-        super(key, **options)
+        super
+      end
+    end
+
+    def set(id, value)
+      _instrument 'set', id: id do
+        super
+      end
+    end
+
+    def delete(id)
+      _instrument 'delete', id: id do
+        super
+      end
+    end
+
+    def index(json)
+      _instrument 'index', id: json.dig('sys', 'id') do
+        super
+      end
+    end
+
+    def find_by(**params)
+      _instrument 'find_by', params.slice(:content_type, :filter, :options) do
+        super
+      end
+    end
+
+    def find_all(**params)
+      _instrument 'find_all', params.slice(:content_type, :options) do
+        super
       end
     end
   end

--- a/wcc-contentful/lib/wcc/contentful/store/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/instrumentation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../instrumentation'
+
+module WCC::Contentful::Store
+  module Instrumentation
+    extend ActiveSupport::Concern
+
+    included do
+      include WCC::Contentful::Instrumentation
+
+      def _instrumentation_event_prefix
+        '.store.contentful.wcc'
+      end
+
+      prepend InstrumentationWrapper
+    end
+  end
+
+  module InstrumentationWrapper
+    def find(key, **options)
+      _instrument 'find', id: key, options: options do
+        super(key, **options)
+      end
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/store/lazy_cache_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/lazy_cache_store.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'instrumentation'
+
 module WCC::Contentful::Store
   class LazyCacheStore
+    include WCC::Contentful::Store::Instrumentation
+
     def initialize(client, cache: nil)
       @cdn = CDNAdapter.new(client)
       @cache = cache || ActiveSupport::Cache::MemoryStore.new
@@ -9,12 +13,15 @@ module WCC::Contentful::Store
     end
 
     def find(key, **options)
+      event = 'fresh'
       found =
         @cache.fetch(key) do
+          event = 'miss'
           # if it's not a contentful ID don't hit the API.
           # Store a nil object if we can't find the object on the CDN.
           (@cdn.find(key, options) || nil_obj(key)) if key =~ /^\w+$/
         end
+      _instrument(event + '.lazycachestore', key: key, options: options)
 
       case found.try(:dig, 'sys', 'type')
       when 'Nil', 'DeletedEntry', 'DeletedAsset'

--- a/wcc-contentful/lib/wcc/contentful/store/lazy_cache_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/lazy_cache_store.rb
@@ -71,8 +71,10 @@ module WCC::Contentful::Store
 
       case json.dig('sys', 'type')
       when 'DeletedEntry', 'DeletedAsset'
+        _instrument 'delete', id: id
         nil
       else
+        _instrument 'set', id: id
         json
       end
     end

--- a/wcc-contentful/lib/wcc/contentful/store/memory_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/memory_store.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'instrumentation'
+
 module WCC::Contentful::Store
   class MemoryStore < Base
+    include WCC::Contentful::Store::Instrumentation
+
     def initialize
       super
       @hash = {}

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
@@ -4,9 +4,12 @@ gem 'pg', '~> 1.0'
 gem 'connection_pool', '~> 2.2'
 require 'pg'
 require 'connection_pool'
+require_relative 'instrumentation'
 
 module WCC::Contentful::Store
   class PostgresStore < Base
+    include WCC::Contentful::Store::Instrumentation
+
     attr_reader :connection_pool
 
     def initialize(_config = nil, connection_options = nil, pool_options = nil)

--- a/wcc-contentful/spec/spec_helper.rb
+++ b/wcc-contentful/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'vcr'
 require 'httplog'
 require 'byebug'
 require 'wisper/rspec/matchers'
+require 'rspec-instrumentation-matcher'
 
 require 'bench_helper'
 

--- a/wcc-contentful/spec/support/store_examples.rb
+++ b/wcc-contentful/spec/support/store_examples.rb
@@ -158,6 +158,24 @@ RSpec.shared_examples 'contentful store' do
       expect(prior2).to eq(data)
       expect(subject.find('1234')).to eq(data2)
     end
+
+    it 'instruments set' do
+      data = { 'key' => 'val', '1' => { 'deep' => 9 } }
+
+      expect {
+        # act
+        subject.set('1234', data)
+      }.to instrument('set.store.contentful.wcc')
+        .with(hash_including(id: '1234'))
+    end
+
+    it 'instruments find' do
+      expect {
+        # act
+        subject.find('1234')
+      }.to instrument('find.store.contentful.wcc')
+        .with(hash_including(id: '1234'))
+    end
   end
 
   describe '#delete' do
@@ -183,6 +201,14 @@ RSpec.shared_examples 'contentful store' do
       # assert
       expect(deleted).to be_nil
       expect(subject.find('9999')).to eq(data)
+    end
+
+    it 'instruments delete' do
+      expect {
+        # act
+        subject.delete('1234')
+      }.to instrument('delete.store.contentful.wcc')
+        .with(hash_including(id: '1234'))
     end
   end
 
@@ -369,6 +395,31 @@ RSpec.shared_examples 'contentful store' do
       # assert
       expect(latest).to eq(existing)
       expect(subject.find(deleted_asset.dig('sys', 'id'))).to eq(existing)
+    end
+
+    it 'instruments index set' do
+      expect {
+        expect {
+          # act
+          subject.index(entry)
+        }.to instrument('index.store.contentful.wcc')
+          .with(hash_including(id: '1qLdW7i7g4Ycq6i4Cckg44'))
+      }.to instrument('set.store.contentful.wcc')
+        .with(hash_including(id: '1qLdW7i7g4Ycq6i4Cckg44'))
+    end
+
+    it 'instruments index delete' do
+      existing = { 'test' => { 'data' => 'asdf' } }
+      subject.set('6HQsABhZDiWmi0ekCouUuy', existing)
+
+      expect {
+        expect {
+          # act
+          subject.index(deleted_entry)
+        }.to instrument('index.store.contentful.wcc')
+          .with(hash_including(id: '6HQsABhZDiWmi0ekCouUuy'))
+      }.to instrument('delete.store.contentful.wcc')
+        .with(hash_including(id: '6HQsABhZDiWmi0ekCouUuy'))
     end
   end
 
@@ -576,6 +627,13 @@ RSpec.shared_examples 'contentful store' do
       expect(links[1].dig('fields', 'subLink', 'en-US', 'sys', 'type'))
         .to eq('Link')
     end
+
+    it 'instruments find_by' do
+      expect {
+        subject.find_by(content_type: 'test2')
+      }.to instrument('find_by.store.contentful.wcc')
+        .with(hash_including(content_type: 'test2'))
+    end
   end
 
   describe '#find_all' do
@@ -642,6 +700,13 @@ RSpec.shared_examples 'contentful store' do
       # assert
       expect(found.count).to eq(1)
       expect(found.first.dig('sys', 'id')).to eq('k5')
+    end
+
+    it 'instruments find_all' do
+      expect {
+        subject.find_all(content_type: 'test2')
+      }.to instrument('find_all.store.contentful.wcc')
+        .with(hash_including(content_type: 'test2'))
     end
   end
 

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -84,6 +84,15 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     expect(main_menu.name).to eq('Main Menu')
   end
 
+  it 'instruments find' do
+    @schema = subject.build_models
+
+    # act
+    expect {
+      WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+    }.to instrument('find.model.contentful.wcc')
+  end
+
   it 'returns nil if cannot find ID' do
     @schema = subject.build_models
 
@@ -148,6 +157,15 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     )
   end
 
+  it 'instruments find_all' do
+    @schema = subject.build_models
+
+    # act
+    expect {
+      WCC::Contentful::Model::MenuButton.find_all(button_style: 'custom')
+    }.to instrument('find_all.model.contentful.wcc')
+  end
+
   it 'returns empty array if find_all finds nothing' do
     @schema = subject.build_models
     store_resp = double
@@ -174,6 +192,15 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     # assert
     expect(redirect).to_not be_nil
     expect(redirect.pageReference.title).to eq('Conferences')
+  end
+
+  it 'instruments find_by' do
+    @schema = subject.build_models
+
+    # act
+    expect {
+      WCC::Contentful::Model::Redirect2.find_by(slug: 'mister_roboto')
+    }.to instrument('find_by.model.contentful.wcc')
   end
 
   it 'returns nil if find_by finds nothing' do

--- a/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe WCC::Contentful::SimpleClient::Management do
 
           expect {
             client.content_types(limit: 1000)
-          }.to instrument('get_http.simple_client.contentful.wcc')
+          }.to instrument('get_http.simpleclient.contentful.wcc')
 
           expect {
             client.content_types(limit: 1000)
-          }.to instrument('content_types.simple_client.contentful.wcc')
+          }.to instrument('content_types.simpleclient.contentful.wcc')
         end
       end
 

--- a/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe WCC::Contentful::SimpleClient::Management do
           resp.assert_ok!
           expect(resp.items.force).to eq([])
         end
+
+        it 'notifies' do
+          stub_request(:get, 'https://api.contentful.com/spaces/testspace/environments/testenv/content_types?limit=1000')
+            .with(headers: { Authorization: 'Bearer testtoken' })
+            .to_return(body: '{ "skip": 0, "total": 0, "items": [] }')
+
+          expect {
+            client.content_types(limit: 1000)
+          }.to instrument('get_http.simple_client.contentful.wcc')
+
+          expect {
+            client.content_types(limit: 1000)
+          }.to instrument('content_types.simple_client.contentful.wcc')
+        end
       end
 
       describe '#content_type' do

--- a/wcc-contentful/spec/wcc/contentful/store/lazy_cache_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/lazy_cache_store_spec.rb
@@ -192,6 +192,23 @@ RSpec.describe WCC::Contentful::Store::LazyCacheStore do
       expect(main_menu2).to eq(main_menu)
     end
 
+    it 'instruments find_all' do
+      stub_request(:get, "https://cdn.contentful.com/spaces/#{contentful_space_id}/entries")
+        .with(query: hash_including({
+          include: '2',
+          content_type: 'menu'
+        }))
+        .to_return(body: load_fixture('contentful/lazy_cache_store/query_main_menu.json'))
+
+      expect {
+        store.find_all(content_type: 'menu', options: { include: 2 })
+      }.to instrument('find_all.store.contentful.wcc')
+        .with(hash_including(
+                content_type: 'menu',
+                options: { include: 2 }
+              ))
+    end
+
     context 'cache_response: true' do
       it 'caches all response items' do
         stub_request(:get, "https://cdn.contentful.com/spaces/#{contentful_space_id}/entries")
@@ -385,6 +402,18 @@ RSpec.describe WCC::Contentful::Store::LazyCacheStore do
       expect(section0.dig('sys', 'type')).to eq('Link')
       section1 = queried_page.dig('fields', 'sections', 'en-US', 1)
       expect(section1.dig('sys', 'type')).to eq('Entry')
+    end
+
+    it 'instruments find_by' do
+      store.set(page.dig('sys', 'id'), page)
+
+      expect {
+        store.find_by(content_type: 'page', filter: { 'sys.id' => page.dig('sys', 'id') })
+      }.to instrument('find_by.store.contentful.wcc')
+        .with(hash_including(
+                content_type: 'page',
+                filter: { 'sys.id' => page.dig('sys', 'id') }
+              ))
     end
 
     context 'cache_response: true' do
@@ -637,6 +666,46 @@ RSpec.describe WCC::Contentful::Store::LazyCacheStore do
       # assert
       expect(latest).to eq(existing)
       expect(subject.find(deleted_entry.dig('sys', 'id'))).to eq(existing)
+    end
+
+    it 'instruments index - no set when entry not cached' do
+      expect {
+        expect {
+          # act
+          subject.index(entry)
+        }.to instrument('index.store.contentful.wcc')
+          .with(hash_including(id: '1qLdW7i7g4Ycq6i4Cckg44'))
+      }.to_not instrument('set.store.contentful.wcc')
+    end
+
+    it 'instruments index - set when entry cached' do
+      new_entry = entry.merge({
+        'sys' => entry['sys'].merge({ 'revision': 2 })
+      })
+      subject.set('1qLdW7i7g4Ycq6i4Cckg44', entry)
+
+      expect {
+        expect {
+          # act
+          subject.index(new_entry)
+        }.to instrument('index.store.contentful.wcc')
+          .with(hash_including(id: '1qLdW7i7g4Ycq6i4Cckg44'))
+      }.to instrument('set.store.contentful.wcc')
+        .with(hash_including(id: '1qLdW7i7g4Ycq6i4Cckg44'))
+    end
+
+    it 'instruments index delete' do
+      existing = { 'test' => { 'data' => 'asdf' } }
+      subject.set('6HQsABhZDiWmi0ekCouUuy', existing)
+
+      expect {
+        expect {
+          # act
+          subject.index(deleted_entry)
+        }.to instrument('index.store.contentful.wcc')
+          .with(hash_including(id: '6HQsABhZDiWmi0ekCouUuy'))
+      }.to instrument('delete.store.contentful.wcc')
+        .with(hash_including(id: '6HQsABhZDiWmi0ekCouUuy'))
     end
   end
 end

--- a/wcc-contentful/wcc-contentful.gemspec
+++ b/wcc-contentful/wcc-contentful.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'wisper-rspec'
+  spec.add_development_dependency 'rspec-instrumentation-matcher'
 
   # Makes testing easy via `bundle exec guard`
   spec.add_development_dependency 'guard', '~> 2.14'

--- a/wcc-contentful/wcc-contentful.gemspec
+++ b/wcc-contentful/wcc-contentful.gemspec
@@ -31,13 +31,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'httplog', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-instrumentation-matcher'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'
   spec.add_development_dependency 'rubocop', '0.68'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'vcr', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'wisper-rspec'
-  spec.add_development_dependency 'rspec-instrumentation-matcher'
 
   # Makes testing easy via `bundle exec guard`
   spec.add_development_dependency 'guard', '~> 2.14'


### PR DESCRIPTION
Adds instrumentation to various layers of the wcc-contentful stack using the ActiveSupport::Notifications library.

refs https://github.com/watermarkchurch/paper-signs/issues/1355