### PR TITLE
206 postgres include param

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -23,4 +23,4 @@ unless declared_trivial
 end
 
 # Run all checks in WM plugin
-wcc.all(reek: false, rubocop: false)
+wcc.all(reek: false, rubocop_exceptions: false, jshint: false, commit_lint: false)

--- a/wcc-contentful/lib/wcc/contentful/store/README.md
+++ b/wcc-contentful/lib/wcc/contentful/store/README.md
@@ -1,0 +1,85 @@
+# Store API
+
+The Store layer is used by the Model API to access Contentful data in a raw form.
+The Store layer returns entries as hashes parsed from JSON, conforming to the
+object structure returned from the Contentful CDN.
+
+## Public Interface
+
+See WCC::Contentful::Store::Interface in wcc/contentful/store/interface.rb
+
+This is the interface consumed by higher layers, such as the Model and GraphQL
+APIs.  It implements the following methods:
+
+* `index?` - Returns boolean true if the SyncEngine should call the store's `index(json)`
+  method with the results of a Sync.
+* `index(json)` - Updates the store with the latest data.  The JSON can be an Entry,
+  Asset, DeletedEntry, or DeletedAsset.
+* `find(id)` - Finds an entry or asset by it's ID.
+* `find_all(content_type:, options: nil)` - Returns a query object that can be
+  enumerated to lazily iterate over all values of a content type.  Query conditions
+  can be applied on the query object before it is enumerated to restrict the result
+  set.
+* `find_by(content_type:, filter: nil, options: nil)` - Returns the first entry 
+  of the given content type which matches the filter.  
+  Note: assets have the special content
+    type of `Asset` (capital A)
+
+## Implementing your own store
+
+The most straightforward way to implement a store is to include the
+WCC::Contentful::Store::Interface module and then override all the defined
+methods.  The easiest way however, is to inherit from WCC::Contentful::Store::Base
+and override the `set`, `delete`, `find`, and `execute` methods.
+
+Let's take a look at the MemoryStore for a simplistic example.  The MemoryStore
+stores entries in a simple Ruby hash keyed by entry ID.  `set` is simply
+assigning to the key in the hash and returning the old value. `delete` and `find`
+are likewise simple.  The only complex method is `execute`, because it powers the
+`find_by` and `find_all` query methods.
+
+The query passed in to `execute` is an instance of WCC::Contentful::Store::Query.
+This object contains a set of WCC::Contentful::Store::Query::Condition structs.
+Each struct is a tuple of `path`, `op`, and `expected`.  `op` is one of
+WCC::Contentful::Store::Query::Interface::OPERATORS, `path` is an array of fields
+pointing to a value in the JSON representation of an entry, and `expected` is the
+expected value that should be compared to the value selected by `path`.
+
+Since the MemoryStore only implements the equality operator, it simply digs
+out the value at the given path using `val = entry.dig(*condition.path)`
+and compares it using Contentful's definition of equality:
+```rb
+# For arrays, equality is defined as does the array include the expected value.
+# See https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/array-equality-inequality
+if val.is_a? Array
+  val.include?(condition.expected)
+else
+  val == condition.expected
+end
+```
+
+### RSpec shared examples
+
+To ensure you have implemented all the appropriate behavior, there
+are a set of rspec shared examples in wcc/contentful/store/rspec_examples.rb which
+you can include in your specs for your store implementation.  Let's look at
+spec/wcc/contentful/store/memory_store_spec.rb to see how it's used:
+
+```rb
+require 'wcc/contentful/store/rspec_examples'
+
+RSpec.describe WCC::Contentful::Store::MemoryStore do
+  subject { WCC::Contentful::Store::MemoryStore.new }
+
+  it_behaves_like 'contentful store', {
+    # memory store does not support JOINs like `Player.find_by(team: { slug: 'dallas-cowboys' })
+    nested_queries: false,
+    # Memory store supports resolving includes, but it does so in the most naiive
+    # way possible (by recursing down the entry's links and calling #find on every one)
+    include_param: 0
+  }
+```
+
+The hash passed to the shared examples describes the features that the store
+supports.  Any key not provided causes the specs to be given the 'pending'
+attribute.  You can disable a set of specs by providing `false` for that key.

--- a/wcc-contentful/lib/wcc/contentful/store/base.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/base.rb
@@ -115,7 +115,7 @@ module WCC::Contentful::Store
       raise ArgumentError, 'Value must be a Hash' unless val.is_a?(Hash)
     end
 
-    protected
+    private
 
     attr_reader :mutex
   end

--- a/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
@@ -58,8 +58,11 @@ module WCC::Contentful::Store
       include WCC::Contentful::Store::Query::Interface
       include Enumerable
 
+      # by default all enumerable methods delegated to the lazy enumerable
+      delegate(*(Enumerable.instance_methods - Module.instance_methods), to: :to_enum)
+
+      # response.count gets the number of items
       delegate :count, to: :response
-      delegate :each, to: :to_enum
 
       def to_enum
         return response.items unless @options[:include]

--- a/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
@@ -148,7 +148,7 @@ module WCC::Contentful::Store
       def resolve_includes(entry, depth)
         return entry unless entry && depth && depth > 0
 
-        WCC::Contentful::LinkVisitor.new(entry, :Link, :Asset, depth: depth).map! do |val|
+        WCC::Contentful::LinkVisitor.new(entry, :Link, :Asset, depth: depth - 1).map! do |val|
           resolve_link(val)
         end
       end

--- a/wcc-contentful/lib/wcc/contentful/store/interface.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/interface.rb
@@ -36,7 +36,7 @@ module WCC::Contentful::Store
     # Finds an entry by it's ID.  The returned entry is a JSON hash
     # @abstract Subclasses should implement this at a minimum to provide data
     #   to the WCC::Contentful::Model API.
-    # sig {abstract.params(id: T::String).returns(T.any(Entry, Asset))}
+    # sig {abstract.params(id: String).returns(T.any(Entry, Asset))}
     def find(_id)
       raise NotImplementedError, "#{self.class} does not implement #find"
     end
@@ -48,6 +48,11 @@ module WCC::Contentful::Store
     #  See WCC::Contentful::Store::Base::Query
     # @param [Hash] options An optional set of additional parameters to the query
     #  defining for example include depth.  Not all store implementations respect all options.
+    # sig {abstract.params(
+    #   content_type: String,
+    #   filter: T.nilable(T::Hash[T.any(Symbol, String), T.untyped]),
+    #   options: T.nilable(T::Hash[T.any(Symbol), T.untyped]),
+    # ).returns(T.any(Entry, Asset))}
     def find_by(content_type:, filter: nil, options: nil)
       raise NotImplementedError, "#{self.class} does not implement #find_by"
     end
@@ -56,10 +61,17 @@ module WCC::Contentful::Store
     #
     # Subclasses may override this to provide their own query implementation,
     #  or else override #execute to run the query after it has been parsed.
+    #
     # @param [String] content_type The ID of the content type to search for.
     # @param [Hash] options An optional set of additional parameters to the query
     #  defining for example include depth.  Not all store implementations respect all options.
-    # @return [Query] A query object that exposes methods to apply filters
+    # @return [Query] A query object that exposes methods to apply filters.
+    #  @see WCC::Contentful::Store::Query::Interface
+    # sig {abstract.params(
+    #   content_type: String,
+    #   filter: T.nilable(T::Hash[T.any(Symbol, String), T.untyped]),
+    #   options: T.nilable(T::Hash[T.any(Symbol), T.untyped]),
+    # ).returns(WCC::Contentful::Store::Query::Interface)}
     def find_all(content_type:, options: nil)
       raise NotImplementedError, "#{self.class} does not implement #find_all"
     end

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
@@ -290,54 +290,7 @@ module WCC::Contentful::Store
 
     class << self
       def ensure_schema(conn)
-        conn.exec(<<~HEREDOC
-          CREATE TABLE IF NOT EXISTS contentful_raw (
-            id varchar PRIMARY KEY,
-            data jsonb,
-            links text[]
-          );
-          ALTER TABLE contentful_raw ADD COLUMN IF NOT EXISTS links text[];
-          CREATE INDEX IF NOT EXISTS contentful_raw_value_type ON contentful_raw ((data->'sys'->>'type'));
-          CREATE INDEX IF NOT EXISTS contentful_raw_value_content_type ON contentful_raw ((data->'sys'->'contentType'->'sys'->>'id'));
-
-          CREATE or replace FUNCTION "fn_contentful_upsert_entry"(_id varchar, _data jsonb, _links text[]) RETURNS jsonb AS $$
-          DECLARE
-            prev jsonb;
-          BEGIN
-            SELECT data, links FROM contentful_raw WHERE id = _id INTO prev;
-            INSERT INTO contentful_raw (id, data, links) values (_id, _data, _links)
-              ON CONFLICT (id) DO
-                UPDATE
-                SET data = _data,
-                  links = _links;
-            RETURN prev;
-          END;
-          $$ LANGUAGE 'plpgsql';
-
-          CREATE MATERIALIZED VIEW IF NOT EXISTS contentful_raw_includes_ids_jointable AS
-            WITH RECURSIVE includes (root_id, depth) AS (
-              SELECT t.id as root_id, 0, t.id, t.links FROM contentful_raw t
-              UNION ALL
-                SELECT l.root_id, l.depth + 1, r.id, r.links
-                FROM includes l, contentful_raw r
-                WHERE r.id = ANY(l.links) AND l.depth < 5
-            )
-            SELECT DISTINCT root_id as id, id as included_id
-              FROM includes;
-
-          CREATE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id ON contentful_raw_includes_ids_jointable (id);
-          CREATE UNIQUE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id_included_id ON contentful_raw_includes_ids_jointable (id, included_id);
-
-          CREATE OR REPLACE VIEW contentful_raw_includes AS
-            SELECT t.id, t.data, array_remove(array_agg(r_incl.data), NULL) as includes
-              FROM contentful_raw t
-              LEFT JOIN contentful_raw_includes_ids_jointable incl ON t.id = incl.id
-              LEFT JOIN contentful_raw r_incl ON r_incl.id = incl.included_id
-              GROUP BY t.id, t.data;
-
-
-        HEREDOC
-        )
+        conn.exec(File.read(File.join(__dir__, 'postgres_store/schema.sql')))
       end
 
       def prepare_statements(conn)

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
@@ -280,7 +280,7 @@ module WCC::Contentful::Store
           END;
           $$ LANGUAGE 'plpgsql';
 
-          CREATE MATERIALIZED VIEW contentful_raw_includes_ids_jointable AS
+          CREATE MATERIALIZED VIEW IF NOT EXISTS contentful_raw_includes_ids_jointable AS
             WITH RECURSIVE includes (root_id, depth) AS (
               SELECT t.id as root_id, 0, t.id, t.links FROM contentful_raw t
               UNION ALL
@@ -292,7 +292,7 @@ module WCC::Contentful::Store
               FROM includes
               WHERE id != root_id;
 
-          CREATE VIEW contentful_raw_includes AS
+          CREATE OR REPLACE VIEW contentful_raw_includes AS
             SELECT t.id, t.data, array_remove(array_agg(r_incl.data), NULL) as includes
               FROM contentful_raw t
               LEFT JOIN contentful_raw_includes_ids_jointable incl ON t.id = incl.id

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
@@ -286,11 +286,10 @@ module WCC::Contentful::Store
               UNION ALL
                 SELECT l.root_id, l.depth + 1, r.id, r.links
                 FROM includes l, contentful_raw r
-                WHERE r.id = ANY(l.links)
+                WHERE r.id = ANY(l.links) AND l.depth < 5
             )
             SELECT DISTINCT root_id as id, id as included_id
-              FROM includes
-              WHERE id != root_id;
+              FROM includes;
 
           CREATE OR REPLACE VIEW contentful_raw_includes AS
             SELECT t.id, t.data, array_remove(array_agg(r_incl.data), NULL) as includes

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
@@ -1,9 +1,15 @@
+CREATE TABLE IF NOT EXISTS wcc_contentful_schema_version (
+  version integer PRIMARY KEY,
+  updated_at timestamp DEFAULT now()
+);
+
+START TRANSACTION;
+
 CREATE TABLE IF NOT EXISTS contentful_raw (
   id varchar PRIMARY KEY,
   data jsonb,
   links text[]
 );
-ALTER TABLE contentful_raw ADD COLUMN IF NOT EXISTS links text[];
 CREATE INDEX IF NOT EXISTS contentful_raw_value_type ON contentful_raw ((data->'sys'->>'type'));
 CREATE INDEX IF NOT EXISTS contentful_raw_value_content_type ON contentful_raw ((data->'sys'->'contentType'->'sys'->>'id'));
 
@@ -41,3 +47,8 @@ CREATE OR REPLACE VIEW contentful_raw_includes AS
     LEFT JOIN contentful_raw_includes_ids_jointable incl ON t.id = incl.id
     LEFT JOIN contentful_raw r_incl ON r_incl.id = incl.included_id
     GROUP BY t.id, t.data;
+
+INSERT INTO wcc_contentful_schema_version
+  VALUES (1);
+
+COMMIT;

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
@@ -48,8 +48,9 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS contentful_raw_includes_ids_jointable AS
       FROM includes l, contentful_raw r
       WHERE r.id = ANY(l.links) AND l.depth < 5
   )
-  SELECT DISTINCT root_id as id, id as included_id, depth
-    FROM includes;
+  SELECT root_id as id, id as included_id, min(depth)
+    FROM includes
+    GROUP BY root_id, id;
 
 CREATE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id ON contentful_raw_includes_ids_jointable (id);
 CREATE UNIQUE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id_included_id ON contentful_raw_includes_ids_jointable (id, included_id);

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
@@ -6,13 +6,17 @@ CREATE TABLE IF NOT EXISTS wcc_contentful_schema_version (
 START TRANSACTION;
 
 CREATE TABLE IF NOT EXISTS contentful_raw (
+  -- The Contentful 'sys'->'id'
   id varchar PRIMARY KEY,
+  -- The contentful entry
   data jsonb,
+  -- Every ID that this entry links to in 'fields'->*->[each locale]->'sys'->'id'
   links text[]
 );
 CREATE INDEX IF NOT EXISTS contentful_raw_value_type ON contentful_raw ((data->'sys'->>'type'));
 CREATE INDEX IF NOT EXISTS contentful_raw_value_content_type ON contentful_raw ((data->'sys'->'contentType'->'sys'->>'id'));
 
+-- Insert or update a Contentful entry by it's ID
 CREATE or replace FUNCTION "fn_contentful_upsert_entry"(_id varchar, _data jsonb, _links text[]) RETURNS jsonb AS $$
 DECLARE
   prev jsonb;
@@ -27,6 +31,15 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+-- Joins the entries table to itself by all the linked entries down to depth 5.
+-- Each entry has a row for each downstream entry in it's tree.
+-- Example:
+--  | id    | included_id | depth |
+--  | page1 | page2       | 1     |
+--  | page1 | subpage2    | 2     | -- through page2
+--  | page1 | asset1      | 1     |
+--  | page2 | subpage2    | 1     |
+--  ...
 CREATE MATERIALIZED VIEW IF NOT EXISTS contentful_raw_includes_ids_jointable AS
   WITH RECURSIVE includes (root_id, depth) AS (
     SELECT t.id as root_id, 0, t.id, t.links FROM contentful_raw t
@@ -35,12 +48,17 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS contentful_raw_includes_ids_jointable AS
       FROM includes l, contentful_raw r
       WHERE r.id = ANY(l.links) AND l.depth < 5
   )
-  SELECT DISTINCT root_id as id, id as included_id
+  SELECT DISTINCT root_id as id, id as included_id, depth
     FROM includes;
 
 CREATE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id ON contentful_raw_includes_ids_jointable (id);
 CREATE UNIQUE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id_included_id ON contentful_raw_includes_ids_jointable (id, included_id);
 
+-- Uses the contentful_raw_includes_ids_jointable to join the entries table to itself,
+-- aggregating the included entries into an array.
+-- Example:
+--  | id    | data  | includes                                    |
+--  | page1 | jsonb | {page2 jsonb, subpage2 jsonb, asset1 jsonb} |
 CREATE OR REPLACE VIEW contentful_raw_includes AS
   SELECT t.id, t.data, array_remove(array_agg(r_incl.data), NULL) as includes
     FROM contentful_raw t

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store/schema.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS contentful_raw (
+  id varchar PRIMARY KEY,
+  data jsonb,
+  links text[]
+);
+ALTER TABLE contentful_raw ADD COLUMN IF NOT EXISTS links text[];
+CREATE INDEX IF NOT EXISTS contentful_raw_value_type ON contentful_raw ((data->'sys'->>'type'));
+CREATE INDEX IF NOT EXISTS contentful_raw_value_content_type ON contentful_raw ((data->'sys'->'contentType'->'sys'->>'id'));
+
+CREATE or replace FUNCTION "fn_contentful_upsert_entry"(_id varchar, _data jsonb, _links text[]) RETURNS jsonb AS $$
+DECLARE
+  prev jsonb;
+BEGIN
+  SELECT data, links FROM contentful_raw WHERE id = _id INTO prev;
+  INSERT INTO contentful_raw (id, data, links) values (_id, _data, _links)
+    ON CONFLICT (id) DO
+      UPDATE
+      SET data = _data,
+        links = _links;
+  RETURN prev;
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS contentful_raw_includes_ids_jointable AS
+  WITH RECURSIVE includes (root_id, depth) AS (
+    SELECT t.id as root_id, 0, t.id, t.links FROM contentful_raw t
+    UNION ALL
+      SELECT l.root_id, l.depth + 1, r.id, r.links
+      FROM includes l, contentful_raw r
+      WHERE r.id = ANY(l.links) AND l.depth < 5
+  )
+  SELECT DISTINCT root_id as id, id as included_id
+    FROM includes;
+
+CREATE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id ON contentful_raw_includes_ids_jointable (id);
+CREATE UNIQUE INDEX IF NOT EXISTS contentful_raw_includes_ids_jointable_id_included_id ON contentful_raw_includes_ids_jointable (id, included_id);
+
+CREATE OR REPLACE VIEW contentful_raw_includes AS
+  SELECT t.id, t.data, array_remove(array_agg(r_incl.data), NULL) as includes
+    FROM contentful_raw t
+    LEFT JOIN contentful_raw_includes_ids_jointable incl ON t.id = incl.id
+    LEFT JOIN contentful_raw r_incl ON r_incl.id = incl.included_id
+    GROUP BY t.id, t.data;

--- a/wcc-contentful/lib/wcc/contentful/store/query.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/query.rb
@@ -9,16 +9,16 @@ module WCC::Contentful::Store
   # Enumerating the query executes it, caching the result.
   class Query
     include WCC::Contentful::Store::Query::Interface
+    include Enumerable
 
-    delegate :each, to: :to_enum
+    # by default all enumerable methods delegated to the to_enum method
+    delegate(*(Enumerable.instance_methods - Module.instance_methods), to: :to_enum)
 
     # Executes the query against the store and memoizes the resulting enumerable.
     #  Subclasses can override this to provide a more efficient implementation.
     def to_enum
       @to_enum ||=
-        result_set.map do |row|
-          resolve_includes(row, @options[:include])
-        end
+        result_set.map { |row| resolve_includes(row, @options[:include]) }.lazy
     end
 
     attr_reader :store, :content_type, :conditions

--- a/wcc-contentful/lib/wcc/contentful/store/query.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/query.rb
@@ -104,7 +104,9 @@ module WCC::Contentful::Store
     def resolve_includes(entry, depth)
       return entry unless entry && depth && depth > 0
 
-      WCC::Contentful::LinkVisitor.new(entry, :Link, :Asset, depth: depth).map! do |val|
+      WCC::Contentful::LinkVisitor.new(entry, :Link, :Asset,
+        # Walk all the links except for the leaf nodes
+        depth: depth - 1).map! do |val|
         resolve_link(val)
       end
     end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples.rb
@@ -899,26 +899,14 @@ RSpec.shared_examples 'supports include param' do |feature_set|
           .to eq('Link')
       end
 
-      2.upto(5).each do |depth|
+      1.upto(5).each do |depth|
         it "does not call into #find in order to resolve include: #{depth}" do
           skip("supported up to #{feature_set}") if feature_set.is_a?(Integer) && feature_set < depth
 
-          items = [
-            # 0
-            root,
-            # N
-            shallow
-          ]
+          items = [root]
           # 1..N
           1.upto(depth).map do |n|
-            items << deep(n,
-              if n < depth
-                # branch
-                make_link_to("deep#{n + 1}")
-              else
-                # leaf
-                make_link_to('shallow')
-              end)
+            items << deep(n, make_link_to("deep#{n + 1}"))
           end
           items.each { |d| subject.set(d.dig('sys', 'id'), d) }
 

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples.rb
@@ -926,6 +926,32 @@ RSpec.shared_examples 'supports include param' do |feature_set|
           expect(link.dig('sys', 'type')).to eq('Link')
         end
       end
+
+      it 'handles recursion' do
+        items = [
+          deep(0, make_link_to('deep1')),
+          deep(1, make_link_to('deep0'))
+        ]
+        items.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        r0 = subject.find_by(content_type: 'deep', filter: { id: 'deep0' }, options: {
+          include: 4
+        })
+
+        link = r0.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep1')
+        link = link.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep0')
+        link = link.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep1')
+        link = link.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep0')
+      end
     end
 
     describe '#find_all' do
@@ -1016,6 +1042,35 @@ RSpec.shared_examples 'supports include param' do |feature_set|
           end
           expect(results.length).to eq(items.length)
         end
+      end
+
+      it 'handles recursion' do
+        items = [
+          deep(0, make_link_to('deep1')),
+          deep(1, make_link_to('deep0'))
+        ]
+        items.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        results = subject.find_all(content_type: 'deep', options: {
+          include: 4
+        }).to_a
+
+        results = results.sort_by { |entry| entry.dig('sys', 'id') }
+
+        r0 = results[0]
+        link = r0.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep1')
+        link = link.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep0')
+        link = link.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep1')
+        link = link.dig('fields', 'subLink', 'en-US')
+        expect(link.dig('sys', 'type')).to eq('Entry')
+        expect(link.dig('sys', 'id')).to eq('deep0')
       end
     end
   end

--- a/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WCC::Contentful::Store::MemoryStore do
 
   it_behaves_like 'contentful store', {
     nested_queries: false,
-    include_param: true
+    include_param: 0
   }
 
   it 'returns all keys' do

--- a/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe WCC::Contentful::Store::PostgresStore do
 
   it_behaves_like 'contentful store', {
     nested_queries: true,
-    include_param: true
+    include_param: 1
   }
 
   it 'returns all keys' do

--- a/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe WCC::Contentful::Store::PostgresStore do
     begin
       conn = PG.connect(ENV['POSTGRES_CONNECTION'] || { dbname: 'postgres' })
 
-      conn.exec('DROP VIEW IF EXISTS contentful_raw_includes')
-      conn.exec('DROP TABLE IF EXISTS contentful_raw')
+      conn.exec('DROP TABLE IF EXISTS contentful_raw CASCADE')
     ensure
       conn.close
     end

--- a/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe WCC::Contentful::Store::PostgresStore do
     begin
       conn = PG.connect(ENV['POSTGRES_CONNECTION'] || { dbname: 'postgres' })
 
+      conn.exec('DROP TABLE IF EXISTS wcc_contentful_schema_version CASCADE')
       conn.exec('DROP TABLE IF EXISTS contentful_raw CASCADE')
     ensure
       conn.close

--- a/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
@@ -27,6 +27,75 @@ RSpec.describe WCC::Contentful::Store::PostgresStore do
     include_param: 1
   }
 
+  let(:entry) do
+    JSON.parse(<<~JSON)
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "343qxys30lid"
+            }
+          },
+          "id": "Menu1ID",
+          "type": "Entry",
+          "createdAt": "2018-03-09T23:39:27.737Z",
+          "updatedAt": "2018-03-09T23:39:27.737Z",
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menu"
+            }
+          }
+        },
+        "fields": {
+          "title": {
+            "en-US": "Top Nav"
+          },
+          "brandLink": {
+            "en-US": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "HomepageEntryID"
+              }
+            }
+          },
+          "brandIcon": {
+            "en-US": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Asset",
+                "id": "BrandAssetID"
+              }
+            }
+          },
+          "items": {
+            "en-US": [
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "Button1ID"
+                }
+              },
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "Button2ID"
+                }
+              }
+            ]
+          }
+        }
+      }
+    JSON
+  end
+
   it 'returns all keys' do
     data = { 'key' => 'val', '1' => { 'deep' => 9 } }
 
@@ -52,6 +121,54 @@ RSpec.describe WCC::Contentful::Store::PostgresStore do
 
     # assert
     expect(results).to eq([data, data, data])
+  end
+
+  it 'stores links in separate column' do
+    # act
+    subject.set(entry.dig('sys', 'id'), entry)
+
+    # assert
+    row =
+      subject.connection_pool.with do |conn|
+        conn.exec("SELECT * FROM contentful_raw WHERE id = '#{entry.dig('sys', 'id')}'")
+      end
+
+    decoder = PG::TextDecoder::Array.new
+    links = decoder.decode(row[0]['links'])
+    expect(links.sort).to eq(%w[
+                               BrandAssetID
+                               Button1ID
+                               Button2ID
+                               HomepageEntryID
+                             ])
+  end
+
+  it 'updates links in separate column' do
+    old_entry = entry.deep_dup
+    # no items links - pretend it's a field of a different type
+    old_entry['fields']['items']['en-US'] = [
+      'Some Text'
+    ]
+
+    subject.set(old_entry)
+    # act
+    subject.set(entry.dig('sys', 'id'), entry)
+
+    # assert
+    row =
+      subject.connection_pool.with do |conn|
+        conn.exec("SELECT * FROM contentful_raw WHERE id = '#{entry.dig('sys', 'id')}'")
+      end
+
+    decoder = PG::TextDecoder::Array.new
+    links = decoder.decode(row[0]['links'])
+    # includes the items links
+    expect(links.sort).to eq(%w[
+                               BrandAssetID
+                               Button1ID
+                               Button2ID
+                               HomepageEntryID
+                             ])
   end
 
   context 'db does not exist' do


### PR DESCRIPTION
* The Postgres store now supports the include parameter.  
   It resolves includes internally using a materialized view as a jointable, joining the `contentful_raw` table back to itself and grouping the included entries in an array using `array_agg`.



fixes #206