### PR TITLE
find all count

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/middleware/store.rb
+++ b/wcc-contentful/lib/wcc/contentful/middleware/store.rb
@@ -75,13 +75,7 @@ module WCC::Contentful::Middleware::Store
   def resolved_link?(value)
     value.is_a?(Hash) && value.dig('sys', 'type') == 'Entry'
   end
-
-  # The default version of `#select?` returns true for all entries.
-  # Override this with your own implementation.
-  # def select?(_entry)
-  #   true
-  # end
-
+ 
   def has_select? # rubocop:disable Naming/PredicateName
     respond_to?(:select?)
   end

--- a/wcc-contentful/lib/wcc/contentful/middleware/store.rb
+++ b/wcc-contentful/lib/wcc/contentful/middleware/store.rb
@@ -75,7 +75,7 @@ module WCC::Contentful::Middleware::Store
   def resolved_link?(value)
     value.is_a?(Hash) && value.dig('sys', 'type') == 'Entry'
   end
- 
+
   def has_select? # rubocop:disable Naming/PredicateName
     respond_to?(:select?)
   end

--- a/wcc-contentful/lib/wcc/contentful/store/query.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/query.rb
@@ -14,11 +14,14 @@ module WCC::Contentful::Store
     # by default all enumerable methods delegated to the to_enum method
     delegate(*(Enumerable.instance_methods - Module.instance_methods), to: :to_enum)
 
+    # except count, which should not iterate the lazy enumerator
+    delegate :count, to: :result_set
+
     # Executes the query against the store and memoizes the resulting enumerable.
     #  Subclasses can override this to provide a more efficient implementation.
     def to_enum
       @to_enum ||=
-        result_set.map { |row| resolve_includes(row, @options[:include]) }.lazy
+        result_set.lazy.map { |row| resolve_includes(row, @options[:include]) }
     end
 
     attr_reader :store, :content_type, :conditions

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -172,15 +172,28 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     expect(store).to receive(:find_all).and_return(store_resp)
     expect(store_resp).to receive(:apply).and_return(store_resp)
 
-    expect(store_resp).to_not be_nil
-
-    expect(store_resp).to receive(:map).and_return([])
+    expect(store_resp).to receive(:to_enum).and_return([])
 
     # act
     menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'asdf')
 
     # assert
-    expect(menu_items).to eq([])
+    expect(menu_items.to_a).to eq([])
+  end
+
+  it 'delegates #count to the underlying store w/o iterating the enumerable' do
+    @schema = subject.build_models
+    store_resp = double(count: 1234)
+    expect(store).to receive(:find_all).and_return(store_resp)
+    allow(store_resp).to receive(:apply).and_return(store_resp)
+
+    expect(store_resp).to_not receive(:to_enum)
+
+    # act
+    menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'asdf')
+
+    # assert
+    expect(menu_items.count).to eq(1234)
   end
 
   it 'finds single item with filter' do


### PR DESCRIPTION
I want to be able to do this:
```ruby
    relation = Person.find_all(options: { limit: limit, skip: skip, include: 1 })
    count = relation.count
    relation = relation.take(limit)
```

and then `count` should give me the value in the "total" field of the response without iterating all the pages.  This requires wrapping all the lazy enumerators all the way up the stack, whenever possible.
