### PR TITLE
Namespacing the Model layer

### DIFF
--- a/wcc-contentful-app/lib/wcc/contentful/app.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app.rb
@@ -37,7 +37,7 @@ module WCC::Contentful::App
     WCC::Contentful.init!
 
     # Extend all model types w/ validation & extra fields
-    WCC::Contentful.types.each_value do |t|
+    WCC::Contentful::Model.schema.each_value do |t|
       file = File.dirname(__FILE__) + "/model/#{t.name.underscore}.rb"
       require file if File.exist?(file)
     end

--- a/wcc-contentful-app/lib/wcc/contentful/app/markdown_renderer.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/markdown_renderer.rb
@@ -6,6 +6,8 @@ class WCC::Contentful::App::MarkdownRenderer
   attr_reader :options, :extensions
 
   def initialize(options = nil)
+    options = options&.dup
+
     @extensions = {
       autolink: true,
       superscript: true,

--- a/wcc-contentful/README.md
+++ b/wcc-contentful/README.md
@@ -49,7 +49,7 @@ The wcc-contentful gem enables caching at two levels: the HTTP response using [F
 By default, the contentful.rb gem requires the [HTTP library](https://rubygems.org/gems/http).  While simple and straightforward to use, it is not as powerful for caching.  We decided to make our client conform to the [Faraday gem's API](https://github.com/lostisland/faraday).  If you prefer not to use Faraday, you can choose to supply your own HTTP adapter that "quacks like" Faraday (see the [TyphoeusAdapter](https://github.com/watermarkchurch/wcc-contentful/blob/master/wcc-contentful/lib/wcc/contentful/simple_client/typhoeus_adapter.rb) for one implementation).
 
 Using Faraday makes it easy to add Middleware.  As an example, our flagship Rails app that powers watermark.org uses the following configuration in Production, which provides us with instrumentation through statsd, logging, and caching:
-```rb
+```ruby
 config.connection = Faraday.new do |builder|
   builder.use :http_cache,
     shared_cache: false,
@@ -81,7 +81,7 @@ We also took advantage of Rails' naming conventions to automatically infer the c
 
 All our models are automatically generated at startup which improves response times at the expense of initialization time.  In addition, our content model registry allows easy definition of custom models in your `app/models` directory to override fields.  This plays nice with other gems like algoliasearch-rails, which allows you to declaratively manage your Algolia indexes.  Another example from our flagship watermark.org:
 
-```rb
+```ruby
 class Page < WCC::Contentful::Model::Page
   include AlgoliaSearch
 
@@ -399,7 +399,7 @@ allows custom transformation of received entries via the `#select` and `#transfo
 methods.  To create your own middleware simply include {WCC::Contentful::Middleware::Store}
 and implement those methods, then call `use` when configuring the store:
 
-```rb
+```ruby
 config.store :direct do
   use MyMiddleware, param1: 'xxx'
 end

--- a/wcc-contentful/README.md
+++ b/wcc-contentful/README.md
@@ -14,16 +14,20 @@ Table of Contents:
 2. [Installation](#installation)
 3. [Configuration](#configure)
 4. [Usage](#usage)
-  1. [Model API](#wcccontentfulmodel-api)
-  2. [Store API](#store-api)
-  3. [Direct CDN client](#direct-cdn-api-simpleclient)
-  4. [Accessing the APIs](#accessing-the-apis-within-application-code)
+   1. [Model API](#wcccontentfulmodel-api)
+   2. [Store API](#store-api)
+   3. [Direct CDN client](#direct-cdn-api-simpleclient)
+   4. [Accessing the APIs](#accessing-the-apis-within-application-code)
 5. [Architecture](#architecture)
+   1. [Client Layer](#client-layer)
+   2. [Store Layer](#store-layer)
+   3. [Model Layer](#model-layer)
 6. [Test Helpers](#test-helpers)
 7. [Advanced Configuration Example](#advanced-configuration-example)
-8. [Development](#development)
-9. [Contributing](#contributing)
-10. [License](#license)
+8. [Connecting to Multiple Spaces](#connecting-to-multiple-spaces-or-environments)
+9. [Development](#development)
+10. [Contributing](#contributing)
+11. [License](#license)
 
 
 ## Why did you rewrite the Contentful ruby stack?
@@ -327,6 +331,98 @@ end
 
 ![wcc-contentful diagram](./doc-static/wcc-contentful.png)
 
+From the bottom up:
+
+### Client Layer
+
+The {WCC::Contentful::SimpleClient} provides methods to access the [Contentful 
+Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/)
+through your favorite HTTP client gem.  The SimpleClient expects
+an Adapter that conforms to the Faraday interface.
+
+Creating a SimpleClient to connect using different credentials, or to connect
+without setting up all the rest of WCC::Contentful, is easy:
+
+```ruby
+WCC::Contentful::SimpleClient::Cdn.new(
+  # required
+  access_token: 'xxxx',
+  space: '1234',
+  # optional
+  environment: 'staging', # omit to use master
+  default_locale: '*',
+  rate_limit_wait_timeout: 10,
+  instrumentation: ActiveSupport::Notifications,
+  connection: Faraday.new { |builder| ... },
+)
+```
+
+You can also create a {WCC::Contentful::SimpleClient::Preview} to talk to the
+Preview API, or a {WCC::Contentful::SimpleClient::Management} to talk to the
+Management API.
+
+### Store Layer
+
+The Store Layer represents the data store where Contentful entries are kept for
+querying.  By default, `WCC::Contentful.init!` creates a {WCC::Contentful::Store::CDNAdapter}
+which uses a {WCC::Contentful::SimpleClient::Cdn} instance to query entries from
+the [Contentful Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/).  You can also query entries from another
+source like Postgres or an in-memory hash if your data is small enough.
+
+You can also implement your own store if you want!  The gem contains a suite of
+RSpec shared examples that give you a baseline for implementing your own store.
+In your RSpec suite:
+```ruby
+# frozen_string_literal: true
+
+require 'my_store'
+require 'wcc/contentful/store/rspec_examples'
+
+RSpec.describe MyStore do
+  it_behaves_like 'contentful store', {
+    # Set which store features your store implements.  
+    nested_queries: true,  # Does your store implement JOINs?
+    include_param: true    # Does your store resolve links when given the :include option?
+  }
+```
+
+The store is kept up-to-date by the {WCC::Contentful::SyncEngine}.  The `SyncEngine#next` methodcalls the `#index` method on the configured store in order to update
+it with the latest data via the [Contentful Sync API](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/synchronization).  For example,
+the {WCC::Contentful::Store::MemoryStore} uses this to update the hash with the
+newest version of an entry, or delete an entry out of the hash.
+
+#### Store Middleware
+
+The store layer is made up of a base store (which implements {WCC::Contentful::Store::Interface}),
+and optional middleware.  The middleware
+allows custom transformation of received entries via the `#select` and `#transform`
+methods.  To create your own middleware simply include {WCC::Contentful::Middleware::Store}
+and implement those methods, then call `use` when configuring the store:
+
+```rb
+config.store :direct do
+  use MyMiddleware, param1: 'xxx'
+end
+```
+
+The most useful middleware is the {WCC::Contentful::Middleware::Store::CachingMiddleware},
+which enables `:lazy_sync` mode (see {WCC::Contentful::Configuration#store})
+
+### Model Layer
+
+This is the global top layer where your Rails app looks up content similarly to
+ActiveModel.  The models are namespaced under the root class {WCC::Contentful::Model}.
+Each model's implementation of `.find`, `.find_by`, and `.find_all` simply call
+into the configured Store.
+
+The main benefit of the Model layer is lazy link resolution.  When a model's
+property is accessed, if that property is a link that has not been resolved
+yet (for example using the `include: n` parameter on `.find_by`), the model
+will automatically call `#find` on the store to resolve that linked entry.
+
+Note that this can easily result in lots of CDN calls to Contentful!  To optimize
+this you should use the `include` parameter and/or use a different store.
+
 ## Test Helpers
 
 To use the test helpers, include the following in your rails_helper.rb:
@@ -460,6 +556,75 @@ rake wcc_contentful:download_schema
 All configuration options can be found [in the rubydoc](https://www.rubydoc.info/gems/wcc-contentful/WCC/Contentful/Configuration) under
 {WCC::Contentful::Configuration}
 
+## Connecting to multiple spaces or environments
+
+When initializing the WCC::Contentful gem using `WCC::Contentful.init!`, the gem will by default connect to the single
+Contentful space that you specify in the `WCC::Contentful.configure` step.  However the gem is also capable of connecting
+to multiple spaces within the same ruby process!  You just have to create and initialize a namespace.
+
+The {WCC::Contentful::ModelAPI} concern makes this straightforward.  Start by creating your Namespace
+and including the concern:
+```ruby
+# app/models/my_second_space.rb
+class MySecondSpace
+  include WCC::Contentful::ModelAPI
+end
+
+# app/models/other_page.rb
+class OtherPage < MySecondSpace::Page
+end
+```
+
+Then configure it in an initializer:
+```ruby
+# config/initializers/my_second_space.rb
+MySecondSpace.configure do |config|
+  # Make sure to point to a different schema file from your first space!
+  config.schema_file = Rails.root.join('db/second-contentful-schema.json')
+
+  config.access_token = ENV['SECOND_CONTENTFUL_ACCESS_TOKEN']
+  config.preview_token = ENV['SECOND_CONTENTFUL_PREVIEW_ACCESS_TOKEN']
+  config.space = ENV['SECOND_CONTENTFUL_SPACE_ID']
+  config.environment = ENV['CONTENTFUL_ENVIRONMENT']
+end
+```
+
+Finally, use it:
+```ruby
+OtherPage.find('1234')
+# GET https://cdn.contentful.com/spaces/other-space/environments/other-env/entries/1234
+# => #<OtherPage:0x0000000005c71a78 @created_at=2018-04-16 18:41:17 UTC...>
+
+Page.find('1234')
+# GET https://cdn.contentful.com/spaces/first-space/environments/first-env/entries/1234
+# => #<Page:0x0000000001271b70 @created_at=2018-04-15 12:02:14 UTC...>
+```
+
+The ModelAPI defines a second stack of services that you can access for lower level connections:
+```ruby
+store = MySecondSpace.services.store
+# => #<WCC::Contentful::Store::CDNAdapter:0x00007f888edac118
+client = MySecondSpace.services.client
+# => #<WCC::Contentful::SimpleClient::Cdn:0x00007f88942a8888
+preview_client = MySecondSpace.services.preview_client
+# => #<WCC::Contentful::SimpleClient::Preview:0x00007f888ccafa00
+sync_engine = MySecondSpace.services.sync_engine
+# => #<WCC::Contentful::SyncEngine:0x00007f88960b6b40
+```
+Note that the above services are not accessible on {WCC::Contentful::Services.instance}
+or via the {WCC::Contentful::ServiceAccessors}.
+
+### Using a sync store with a second space
+
+If you use something other than the CDNAdapter with your second space, you will
+need to find a way to trigger `MySecondSpace.services.sync_engine.next` to keep
+it up-to-date.  The {WCC::Contentful::Engine} will only manage the global SyncEngine
+configured by the global {WCC::Contentful.configure}.
+
+The easiest way to do this is to set up your own Rails route to respond to Contentful
+webhooks and then configure the second Contentful space to send webhooks to this route.
+You could also do this by triggering it periodically in a background job using
+Sidekiq and [sidekiq-scheduler](https://github.com/Moove-it/sidekiq-scheduler).
 
 ## Development
 

--- a/wcc-contentful/lib/wcc/contentful.rb
+++ b/wcc-contentful/lib/wcc/contentful.rb
@@ -34,7 +34,10 @@ module WCC::Contentful
     # Gets the current configuration, after calling WCC::Contentful.configure
     attr_reader :configuration
 
-    attr_reader :types
+    def types
+      ActiveSupport::Deprecation.warn('Use WCC::Contentful::Model.schema instead')
+      WCC::Contentful::Model.schema
+    end
 
     # Gets all queryable locales.
     # Reserved for future use.
@@ -120,13 +123,12 @@ module WCC::Contentful
         ' Check your access token and space ID.'
     end
 
-    indexer = ContentTypeIndexer.from_json_schema(@content_types)
-    @types = indexer.types
+    # Set the schema on the default WCC::Contentful::Model
+    WCC::Contentful::Model.schema(@content_types)
 
     # Drop an initial sync
     WCC::Contentful::SyncEngine::Job.perform_later if defined?(WCC::Contentful::SyncEngine::Job)
 
-    WCC::Contentful::ModelBuilder.new(@types).build_models
     @configuration = @configuration.freeze
     @initialized = true
   end

--- a/wcc-contentful/lib/wcc/contentful/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/instrumentation.rb
@@ -34,7 +34,7 @@ module WCC::Contentful
           # try looking up the class heierarchy
           superclass.try(:_instrumentation) ||
           # default to global
-          WCC::Contentful::Services.instance&.instrumentation_adapter ||
+          WCC::Contentful::Services.instance&.instrumentation ||
           ActiveSupport::Notifications
       end
     end

--- a/wcc-contentful/lib/wcc/contentful/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/instrumentation.rb
@@ -24,13 +24,12 @@ module WCC::Contentful
       attr_writer :_instrumentation
 
       def _instrumentation
-        @_instrumentation ||=
+        @_instrumentation ||
           # try looking up the class heierarchy
           superclass.try(:_instrumentation) ||
-          # see if we have a services
-          try(:services)&.instrumentation ||
           # default to global
-          WCC::Contentful::Services.instance.instrumentation
+          WCC::Contentful.configuration&.instrumentation_adapter ||
+          ActiveSupport::Notifications
       end
     end
 

--- a/wcc-contentful/lib/wcc/contentful/instrumentation.rb
+++ b/wcc-contentful/lib/wcc/contentful/instrumentation.rb
@@ -16,8 +16,21 @@ module WCC::Contentful
 
       def _instrument(name, payload = {}, &block)
         name += _instrumentation_event_prefix
-        (@_instrumentation ||= WCC::Contentful::Services.instance.instrumentation)
-          .instrument(name, payload, &block)
+        self.class._instrumentation&.instrument(name, payload, &block)
+      end
+    end
+
+    class_methods do
+      attr_writer :_instrumentation
+
+      def _instrumentation
+        @_instrumentation ||=
+          # try looking up the class heierarchy
+          superclass.try(:_instrumentation) ||
+          # see if we have a services
+          try(:services)&.instrumentation ||
+          # default to global
+          WCC::Contentful::Services.instance.instrumentation
       end
     end
 

--- a/wcc-contentful/lib/wcc/contentful/middleware/store.rb
+++ b/wcc-contentful/lib/wcc/contentful/middleware/store.rb
@@ -55,7 +55,8 @@ module WCC::Contentful::Middleware::Store
   def resolve_includes(entry, depth)
     return entry unless entry && depth && depth > 0
 
-    WCC::Contentful::LinkVisitor.new(entry, :Link, depth: depth).map! do |val|
+    # We only care about entries (see #resolved_link?)
+    WCC::Contentful::LinkVisitor.new(entry, :Entry, depth: depth).map! do |val|
       resolve_link(val)
     end
   end

--- a/wcc-contentful/lib/wcc/contentful/model.rb
+++ b/wcc-contentful/lib/wcc/contentful/model.rb
@@ -52,20 +52,6 @@ class WCC::Contentful::Model
         "Content type '#{type}' does not exist in the space"
     end
   end
-
-  @@registry = {}
-
-  def self.store(preview = false)
-    if preview
-      if preview_store.nil?
-        raise ArgumentError,
-          'You must include a contentful preview token in your WCC::Contentful.configure block'
-      end
-      preview_store
-    else
-      super()
-    end
-  end
 end
 
 # rubocop:enable Style/ClassVars

--- a/wcc-contentful/lib/wcc/contentful/model.rb
+++ b/wcc-contentful/lib/wcc/contentful/model.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './model_api'
+
 # This is the top layer of the WCC::Contentful gem.  It exposes an API by which
 # you can query for data from Contentful.  The API is only accessible after calling
 # WCC::Contentful.init!
@@ -37,7 +39,7 @@
 #
 # @api Model
 class WCC::Contentful::Model
-  extend WCC::Contentful::Helpers
+  include WCC::Contentful::ModelAPI
 
   # The Model base class maintains a registry which is best expressed as a
   # class var.
@@ -47,8 +49,9 @@ class WCC::Contentful::Model
     include WCC::Contentful::ServiceAccessors
 
     def const_missing(name)
+      type = WCC::Contentful::Helpers.content_type_from_constant(name)
       raise WCC::Contentful::ContentTypeNotFoundError,
-        "Content type '#{content_type_from_constant(name)}' does not exist in the space"
+        "Content type '#{type}' does not exist in the space"
     end
   end
 
@@ -64,110 +67,6 @@ class WCC::Contentful::Model
     else
       super()
     end
-  end
-
-  # Finds an Entry or Asset by ID in the configured contentful space
-  # and returns an initialized instance of the appropriate model type.
-  #
-  # Makes use of the {WCC::Contentful::Services#store configured store}
-  # to access the Contentful CDN.
-  def self.find(id, options: nil)
-    options ||= {}
-    raw = store(options[:preview])
-      .find(id, options.except(*WCC::Contentful::ModelMethods::MODEL_LAYER_CONTEXT_KEYS))
-
-    new_from_raw(raw, options) if raw.present?
-  end
-
-  # Creates a new initialized instance of the appropriate model type for the
-  # given raw value.  The raw value must be the same format as returned from one
-  # of the stores for a given object.
-  def self.new_from_raw(raw, context = nil)
-    content_type = content_type_from_raw(raw)
-    const = resolve_constant(content_type)
-    const.new(raw, context)
-  end
-
-  # Accepts a content type ID as a string and returns the Ruby constant
-  # stored in the registry that represents this content type.
-  def self.resolve_constant(content_type)
-    raise ArgumentError, 'content_type cannot be nil' unless content_type
-
-    const = @@registry[content_type]
-    return const if const
-
-    const_name = constant_from_content_type(content_type).to_s
-    begin
-      # The app may have defined a model and we haven't loaded it yet
-      const = Object.const_missing(const_name)
-      return const if const && const < WCC::Contentful::Model
-    rescue NameError => e
-      raise e unless e.message =~ /uninitialized constant #{const_name}/
-
-      nil
-    end
-
-    # Autoloading couldn't find their model - we'll register our own.
-    const = WCC::Contentful::Model.const_get(constant_from_content_type(content_type))
-    register_for_content_type(content_type, klass: const)
-  end
-
-  # Registers a class constant to be instantiated when resolving an instance
-  # of the given content type.  This automatically happens for the first subclass
-  # of a generated model type, example:
-  #
-  #   class MyMenu < WCC::Contentful::Model::Menu
-  #   end
-  #
-  # In the above case, instances of MyMenu will be instantiated whenever a 'menu'
-  # content type is resolved.
-  # The mapping can be made explicit with the optional parameters.  Example:
-  #
-  #   class MyFoo < WCC::Contentful::Model::Foo
-  #     register_for_content_type 'bar' # MyFoo is assumed
-  #   end
-  #
-  #   # in initializers/wcc_contentful.rb
-  #   WCC::Contentful::Model.register_for_content_type('bar', klass: MyFoo)
-  def self.register_for_content_type(content_type = nil, klass: nil)
-    klass ||= self
-    raise ArgumentError, "#{klass} must be a class constant!" unless klass.respond_to?(:new)
-
-    content_type ||= content_type_from_constant(klass)
-
-    @@registry[content_type] = klass
-  end
-
-  # Returns the current registry of content type names to constants.
-  def self.registry
-    return {} unless @@registry
-
-    @@registry.dup.freeze
-  end
-
-  def self.reload!
-    registry = self.registry
-    registry.each do |(content_type, klass)|
-      const_name = klass.name
-      begin
-        const = Object.const_missing(const_name)
-        register_for_content_type(content_type, klass: const) if const
-      rescue NameError => e
-        msg = "Error when reloading constant #{const_name} - #{e}"
-        if defined?(Rails) && Rails.logger
-          Rails.logger.error msg
-        else
-          puts msg
-        end
-      end
-    end
-  end
-
-  # Checks if a content type has already been registered to a class and returns
-  # that class.  If nil, the generated WCC::Contentful::Model::{content_type} class
-  # will be resolved for this content type.
-  def self.registered?(content_type)
-    @@registry[content_type]
   end
 end
 

--- a/wcc-contentful/lib/wcc/contentful/model.rb
+++ b/wcc-contentful/lib/wcc/contentful/model.rb
@@ -46,8 +46,6 @@ class WCC::Contentful::Model
   # rubocop:disable Style/ClassVars
 
   class << self
-    include WCC::Contentful::ServiceAccessors
-
     def const_missing(name)
       type = WCC::Contentful::Helpers.content_type_from_constant(name)
       raise WCC::Contentful::ContentTypeNotFoundError,

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -33,7 +33,7 @@ module WCC::Contentful::ModelAPI
         # create it if we have a configuration
         WCC::Contentful::Services.new(configuration)
     end
-    delegate :store, :preview_store, to: :services
+    delegate :_instrumentation, to: :services
 
     def schema
       return @schema if @schema
@@ -55,7 +55,10 @@ module WCC::Contentful::ModelAPI
     def find(id, options: nil)
       options ||= {}
       store = options[:preview] ? services.preview_store : services.store
-      raw = store.find(id, options.except(*WCC::Contentful::ModelMethods::MODEL_LAYER_CONTEXT_KEYS))
+      raw =
+        _instrumentation.instrument 'find.model.contentful.wcc', id: id, options: options do
+          store.find(id, options.except(*WCC::Contentful::ModelMethods::MODEL_LAYER_CONTEXT_KEYS))
+        end
 
       new_from_raw(raw, options) if raw.present?
     end

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module WCC::Contentful::ModelAPI
+  extend ActiveSupport::Concern
+
+  included do
+    # We use a class var here because this is a global registry for all subclasses
+    # of this namespace
+    @@registry = {} # rubocop:disable Style/ClassVars
+  end
+
+  class_methods do
+    def schema(schema_json = nil, file: nil)
+      raise ArgumentError, 'Schema can only be set once!' if @schema && (schema_json || file)
+      return @schema if @schema
+
+      schema_json ||= JSON.parse(File.read(file))['contentTypes'] if file
+      unless schema_json
+        raise ArgumentError, 'Please give either a JSON array of content types or file to load from'
+      end
+
+      @schema = WCC::Contentful::ContentTypeIndexer.from_json_schema(schema_json).types
+      WCC::Contentful::ModelBuilder.new(@schema, namespace: self).build_models
+      @schema
+    end
+
+    def store(new_store = nil)
+      if new_store.present?
+        @store = new_store
+      else
+        @store
+      end
+    end
+
+    def preview_store(new_store = nil)
+      if new_store.present?
+        @preview_store = new_store
+      else
+        @preview_store
+      end
+    end
+
+    # Finds an Entry or Asset by ID in the configured contentful space
+    # and returns an initialized instance of the appropriate model type.
+    #
+    # Makes use of the {WCC::Contentful::Services#store configured store}
+    # to access the Contentful CDN.
+    def find(id, options: nil)
+      options ||= {}
+      store = options[:preview] ? preview_store : self.store
+      raw = store.find(id, options.except(*WCC::Contentful::ModelMethods::MODEL_LAYER_CONTEXT_KEYS))
+
+      new_from_raw(raw, options) if raw.present?
+    end
+
+    # Creates a new initialized instance of the appropriate model type for the
+    # given raw value.  The raw value must be the same format as returned from one
+    # of the stores for a given object.
+    def new_from_raw(raw, context = nil)
+      content_type = WCC::Contentful::Helpers.content_type_from_raw(raw)
+      const = resolve_constant(content_type)
+      const.new(raw, context)
+    end
+
+    # Accepts a content type ID as a string and returns the Ruby constant
+    # stored in the registry that represents this content type.
+    def resolve_constant(content_type)
+      raise ArgumentError, 'content_type cannot be nil' unless content_type
+
+      const = @@registry[content_type]
+      return const if const
+
+      const_name = WCC::Contentful::Helpers.constant_from_content_type(content_type).to_s
+      begin
+        # The app may have defined a model and we haven't loaded it yet
+        const = Object.const_missing(const_name)
+        return const if const && const < WCC::Contentful::Model
+      rescue NameError => e
+        raise e unless e.message =~ /uninitialized constant #{const_name}/
+
+        nil
+      end
+
+      # Autoloading couldn't find their model - we'll register our own.
+      const = WCC::Contentful::Model.const_get(
+        WCC::Contentful::Helpers.constant_from_content_type(content_type)
+      )
+      register_for_content_type(content_type, klass: const)
+    end
+
+    # Registers a class constant to be instantiated when resolving an instance
+    # of the given content type.  This automatically happens for the first subclass
+    # of a generated model type, example:
+    #
+    #   class MyMenu < WCC::Contentful::Model::Menu
+    #   end
+    #
+    # In the above case, instances of MyMenu will be instantiated whenever a 'menu'
+    # content type is resolved.
+    # The mapping can be made explicit with the optional parameters.  Example:
+    #
+    #   class MyFoo < WCC::Contentful::Model::Foo
+    #     register_for_content_type 'bar' # MyFoo is assumed
+    #   end
+    #
+    #   # in initializers/wcc_contentful.rb
+    #   WCC::Contentful::Model.register_for_content_type('bar', klass: MyFoo)
+    def register_for_content_type(content_type = nil, klass: nil)
+      klass ||= self
+      raise ArgumentError, "#{klass} must be a class constant!" unless klass.respond_to?(:new)
+
+      content_type ||= WCC::Contentful::Helpers.content_type_from_constant(klass)
+
+      @@registry[content_type] = klass
+    end
+
+    # Returns the current registry of content type names to constants.
+    def registry
+      return {} unless @@registry
+
+      @@registry.dup.freeze
+    end
+
+    def reload!
+      registry = self.registry
+      registry.each do |(content_type, klass)|
+        const_name = klass.name
+        begin
+          const = Object.const_missing(const_name)
+          register_for_content_type(content_type, klass: const) if const
+        rescue NameError => e
+          msg = "Error when reloading constant #{const_name} - #{e}"
+          if defined?(Rails) && Rails.logger
+            Rails.logger.error msg
+          else
+            puts msg
+          end
+        end
+      end
+    end
+
+    # Checks if a content type has already been registered to a class and returns
+    # that class.  If nil, the generated WCC::Contentful::Model::{content_type} class
+    # will be resolved for this content type.
+    def registered?(content_type)
+      @@registry[content_type]
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -105,9 +105,11 @@ module WCC::Contentful::ModelAPI
           raise e unless e.message =~ /uninitialized constant (.+::)*#{const_name}$/
         end
 
+        # const_missing only searches recursively up the module tree in a Rails
+        # context.  If we're in a non-Rails app, we have to do that recursion ourselves.
+        # Keep looking upwards until we get to Object.
         break if parent == Object
 
-        # Keep looking up the module tree until we get to Object
         parent = parent.try(:module_parent) || parent.parent
       end
 

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -6,6 +6,11 @@ module WCC::Contentful::ModelAPI
   included do
     include WCC::Contentful::Instrumentation
 
+    # override class-level _instrumentation from WCC::Contentful::Instrumentation
+    def self._instrumentation
+      services.instrumentation
+    end
+
     # We use a class var here because this is a global registry for all subclasses
     # of this namespace
     @@registry = {} # rubocop:disable Style/ClassVars
@@ -33,7 +38,6 @@ module WCC::Contentful::ModelAPI
         # create it if we have a configuration
         WCC::Contentful::Services.new(configuration)
     end
-    delegate :_instrumentation, to: :services
 
     def schema
       return @schema if @schema

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -39,6 +39,12 @@ module WCC::Contentful::ModelAPI
         WCC::Contentful::Services.new(configuration)
     end
 
+    def store(preview = nil)
+      ActiveSupport::Deprecation.warn('Use services.store instead')
+
+      preview ? services.preview_store : services.store
+    end
+
     def schema
       return @schema if @schema
 

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -82,7 +82,7 @@ module WCC::Contentful::ModelAPI
       end
 
       # Autoloading couldn't find their model - we'll register our own.
-      const = WCC::Contentful::Model.const_get(
+      const = const_get(
         WCC::Contentful::Helpers.constant_from_content_type(content_type)
       )
       register_for_content_type(content_type, klass: const)

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -27,7 +27,7 @@ module WCC::Contentful::ModelAPI
     def services
       @services ||=
         # try looking up the class heierarchy
-        superclass.try(&:services) ||
+        (superclass.services if superclass.respond_to?(:services)) ||
         # create it if we have a configuration
         WCC::Contentful::Services.new(configuration)
     end

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -4,6 +4,8 @@ module WCC::Contentful::ModelAPI
   extend ActiveSupport::Concern
 
   included do
+    include WCC::Contentful::Instrumentation
+
     # We use a class var here because this is a global registry for all subclasses
     # of this namespace
     @@registry = {} # rubocop:disable Style/ClassVars

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -25,7 +25,11 @@ module WCC::Contentful::ModelAPI
     end
 
     def services
-      @services ||= WCC::Contentful::Services.new(configuration)
+      @services ||=
+        # try looking up the class heierarchy
+        superclass.try(&:services) ||
+        # create it if we have a configuration
+        WCC::Contentful::Services.new(configuration)
     end
     delegate :store, :preview_store, to: :services
 

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -24,11 +24,12 @@ module WCC::Contentful
 
     def build_model(typedef)
       const = typedef.name
-      return namespace.const_get(const) if namespace.const_defined?(const)
+      ns = namespace
+      return ns.const_get(const) if ns.const_defined?(const)
 
       # TODO: https://github.com/dkubb/ice_nine ?
       typedef = typedef.deep_dup.freeze
-      namespace.const_set(const,
+      ns.const_set(const,
         Class.new(namespace) do
           extend ModelSingletonMethods
           include ModelMethods
@@ -51,6 +52,10 @@ module WCC::Contentful
 
           define_singleton_method(:content_type_definition) do
             typedef
+          end
+
+          define_singleton_method(:model_namespace) do
+            ns
           end
 
           define_method(:initialize) do |raw, context = nil|

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -34,6 +34,7 @@ module WCC::Contentful
           extend ModelSingletonMethods
           include ModelMethods
           include Helpers
+          include WCC::Contentful::Instrumentation
 
           const_set('ATTRIBUTES', typedef.fields.keys.map(&:to_sym).freeze)
           const_set('FIELDS', typedef.fields.keys.freeze)
@@ -55,7 +56,6 @@ module WCC::Contentful
           end
 
           define_singleton_method(:model_namespace) { ns }
-          define_singleton_method(:services) { ns.services }
 
           define_method(:initialize) do |raw, context = nil|
             ct = content_type_from_raw(raw)

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -7,8 +7,11 @@ module WCC::Contentful
   class ModelBuilder
     include Helpers
 
-    def initialize(types)
+    attr_reader :namespace
+
+    def initialize(types, namespace: WCC::Contentful::Model)
       @types = types
+      @namespace = namespace
     end
 
     def build_models
@@ -21,12 +24,12 @@ module WCC::Contentful
 
     def build_model(typedef)
       const = typedef.name
-      return WCC::Contentful::Model.const_get(const) if WCC::Contentful::Model.const_defined?(const)
+      return namespace.const_get(const) if namespace.const_defined?(const)
 
       # TODO: https://github.com/dkubb/ice_nine ?
       typedef = typedef.deep_dup.freeze
-      WCC::Contentful::Model.const_set(const,
-        Class.new(WCC::Contentful::Model) do
+      namespace.const_set(const,
+        Class.new(namespace) do
           extend ModelSingletonMethods
           include ModelMethods
           include Helpers

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -54,9 +54,8 @@ module WCC::Contentful
             typedef
           end
 
-          define_singleton_method(:model_namespace) do
-            ns
-          end
+          define_singleton_method(:model_namespace) { ns }
+          define_singleton_method(:services) { ns.services }
 
           define_method(:initialize) do |raw, context = nil|
             ct = content_type_from_raw(raw)

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -34,7 +34,6 @@ module WCC::Contentful
           extend ModelSingletonMethods
           include ModelMethods
           include Helpers
-          include WCC::Contentful::Instrumentation
 
           const_set('ATTRIBUTES', typedef.fields.keys.map(&:to_sym).freeze)
           const_set('FIELDS', typedef.fields.keys.freeze)

--- a/wcc-contentful/lib/wcc/contentful/model_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_methods.rb
@@ -170,10 +170,10 @@ module WCC::Contentful::ModelMethods
           if raw.dig('sys', 'type') == 'Link'
             _instrument 'resolve',
               id: self.id, depth: depth, backlinks: context[:backlinks]&.map(&:id) do
-              WCC::Contentful::Model.find(id, options: new_context)
+              self.class.model_namespace.find(id, options: new_context)
             end
           else
-            WCC::Contentful::Model.new_from_raw(raw, new_context)
+            self.class.model_namespace.new_from_raw(raw, new_context)
           end
 
         m.resolve(depth: depth - 1, context: new_context, **options) if m && depth > 1

--- a/wcc-contentful/lib/wcc/contentful/model_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_methods.rb
@@ -5,8 +5,6 @@
 #
 # @api Model
 module WCC::Contentful::ModelMethods
-  include WCC::Contentful::Instrumentation
-
   # The set of options keys that are specific to the Model layer and shouldn't
   # be passed down to the Store layer.
   MODEL_LAYER_CONTEXT_KEYS = %i[
@@ -40,6 +38,7 @@ module WCC::Contentful::ModelMethods
 
     typedef = self.class.content_type_definition
     links = fields.select { |f| %i[Asset Link].include?(typedef.fields[f].type) }
+    store = context[:preview] ? self.class.services.preview_store : self.class.services.store
 
     raw_link_ids =
       links.map { |field_name| raw.dig('fields', field_name, sys.locale) }
@@ -54,12 +53,11 @@ module WCC::Contentful::ModelMethods
       raw =
         _instrument 'resolve', id: id, depth: depth, backlinks: backlinked_ids do
           # use include param to do resolution
-          self.class.store(context[:preview])
-            .find_by(content_type: self.class.content_type,
-                     filter: { 'sys.id' => id },
-                     options: context.except(*MODEL_LAYER_CONTEXT_KEYS).merge!({
-                       include: [depth, 10].min
-                     }))
+          store.find_by(content_type: self.class.content_type,
+                        filter: { 'sys.id' => id },
+                        options: context.except(*MODEL_LAYER_CONTEXT_KEYS).merge!({
+                          include: [depth, 10].min
+                        }))
         end
       unless raw
         raise WCC::Contentful::ResolveError, "Cannot find #{self.class.content_type} with ID #{id}"

--- a/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
@@ -12,9 +12,9 @@ module WCC::Contentful::ModelSingletonMethods
   #   WCC::Contentful::Model::Page.find(id)
   def find(id, options: nil)
     options ||= {}
-    store = store(options[:preview])
+    store = options[:preview] ? services.preview_store : services.store
     raw =
-      WCC::Contentful::Instrumentation.instrument 'find.model.contentful.wcc',
+      services.instrumentation.instrument 'find.model.contentful.wcc',
         content_type: content_type, id: id, options: options do
         store.find(id, { hint: type }.merge!(options.except(:preview)))
       end
@@ -34,9 +34,9 @@ module WCC::Contentful::ModelSingletonMethods
 
     filter.transform_keys! { |k| k.to_s.camelize(:lower) } if filter.present?
 
-    store = store(options[:preview])
+    store = options[:preview] ? services.preview_store : services.store
     query =
-      WCC::Contentful::Instrumentation.instrument 'find_all.model.contentful.wcc',
+      services.instrumentation.instrument 'find_all.model.contentful.wcc',
         content_type: content_type, filter: filter, options: options do
         store.find_all(content_type: content_type, options: options.except(:preview))
       end
@@ -56,9 +56,9 @@ module WCC::Contentful::ModelSingletonMethods
 
     filter.transform_keys! { |k| k.to_s.camelize(:lower) } if filter.present?
 
-    store = store(options[:preview])
+    store = options[:preview] ? services.preview_store : services.store
     result =
-      WCC::Contentful::Instrumentation.instrument 'find_by.model.contentful.wcc',
+      services.instrumentation.instrument 'find_by.model.contentful.wcc',
         content_type: content_type, filter: filter, options: options do
         store.find_by(content_type: content_type, filter: filter, options: options.except(:preview))
       end

--- a/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
@@ -14,7 +14,7 @@ module WCC::Contentful::ModelSingletonMethods
     options ||= {}
     store = options[:preview] ? services.preview_store : services.store
     raw =
-      services.instrumentation.instrument 'find.model.contentful.wcc',
+      _instrumentation.instrument 'find.model.contentful.wcc',
         content_type: content_type, id: id, options: options do
         store.find(id, { hint: type }.merge!(options.except(:preview)))
       end
@@ -36,7 +36,7 @@ module WCC::Contentful::ModelSingletonMethods
 
     store = options[:preview] ? services.preview_store : services.store
     query =
-      services.instrumentation.instrument 'find_all.model.contentful.wcc',
+      _instrumentation.instrument 'find_all.model.contentful.wcc',
         content_type: content_type, filter: filter, options: options do
         store.find_all(content_type: content_type, options: options.except(:preview))
       end
@@ -58,7 +58,7 @@ module WCC::Contentful::ModelSingletonMethods
 
     store = options[:preview] ? services.preview_store : services.store
     result =
-      services.instrumentation.instrument 'find_by.model.contentful.wcc',
+      _instrumentation.instrument 'find_by.model.contentful.wcc',
         content_type: content_type, filter: filter, options: options do
         store.find_by(content_type: content_type, filter: filter, options: options.except(:preview))
       end

--- a/wcc-contentful/lib/wcc/contentful/rspec.rb
+++ b/wcc-contentful/lib/wcc/contentful/rspec.rb
@@ -12,16 +12,15 @@ module WCC::Contentful::RSpec
   # Builds out a fake Contentful entry for the given content type, and then
   # stubs the Model API to return that content type for `.find` and `.find_by`
   # query methods.
-  def contentful_stub(content_type, **attrs)
-    const = WCC::Contentful::Model.resolve_constant(content_type.to_s)
-    instance = contentful_create(content_type, **attrs)
+  def contentful_stub(const, **attrs)
+    instance = contentful_create(const, **attrs)
 
     # mimic what's going on inside model_singleton_methods.rb
     # find, find_by, etc always return a new instance from the same raw
     allow(WCC::Contentful::Model).to receive(:find)
       .with(instance.id, any_args) do |_id, keyword_params|
         options = keyword_params && keyword_params[:options]
-        contentful_create(content_type, options, raw: instance.raw, **attrs)
+        contentful_create(const, options, raw: instance.raw, **attrs)
       end
     allow(const).to receive(:find) { |id, options| WCC::Contentful::Model.find(id, **(options || {})) }
 
@@ -31,7 +30,7 @@ module WCC::Contentful::RSpec
           filter = filter&.dup
           options = filter&.delete(:options) || {}
 
-          contentful_create(content_type, options, raw: instance.raw, **attrs)
+          contentful_create(const, options, raw: instance.raw, **attrs)
         end
     end
 

--- a/wcc-contentful/lib/wcc/contentful/rspec.rb
+++ b/wcc-contentful/lib/wcc/contentful/rspec.rb
@@ -13,6 +13,9 @@ module WCC::Contentful::RSpec
   # stubs the Model API to return that content type for `.find` and `.find_by`
   # query methods.
   def contentful_stub(const, **attrs)
+    unless const.respond_to?(:content_type_definition)
+      const = WCC::Contentful::Model.resolve_constant(const.to_s)
+    end
     instance = contentful_create(const, **attrs)
 
     # mimic what's going on inside model_singleton_methods.rb

--- a/wcc-contentful/lib/wcc/contentful/services.rb
+++ b/wcc-contentful/lib/wcc/contentful/services.rb
@@ -12,6 +12,8 @@ module WCC::Contentful
     attr_reader :configuration
 
     def initialize(configuration)
+      raise ArgumentError, 'Not yet configured!' unless configuration
+
       @configuration = configuration
     end
 

--- a/wcc-contentful/lib/wcc/contentful/services.rb
+++ b/wcc-contentful/lib/wcc/contentful/services.rb
@@ -8,12 +8,10 @@ module WCC::Contentful
       end
     end
 
-    def configuration
-      @configuration ||= WCC::Contentful.configuration
-    end
+    attr_reader :configuration
 
     def initialize(configuration = nil)
-      @configuration = configuration
+      @configuration = configuration || WCC::Contentful.configuration
     end
 
     # Gets the data-store which executes the queries run against the dynamic

--- a/wcc-contentful/lib/wcc/contentful/services.rb
+++ b/wcc-contentful/lib/wcc/contentful/services.rb
@@ -120,6 +120,8 @@ module WCC::Contentful
 
     # Gets the configured instrumentation adapter, defaulting to ActiveSupport::Notifications
     def instrumentation
+      ActiveSupport::Deprecation.warn('Use ._instrumentation from '\
+        'WCC::Contentful::Instrumentation instead')
       return @instrumentation if @instrumentation
       return ActiveSupport::Notifications if WCC::Contentful.configuration.nil?
 

--- a/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
@@ -158,7 +158,8 @@ module WCC::Contentful::Store
       def resolve_includes(entry, depth)
         return entry unless entry && depth && depth > 0
 
-        WCC::Contentful::LinkVisitor.new(entry, :Link, :Asset, depth: depth - 1).map! do |val|
+        # Dig links out of response.includes and insert them into the entry
+        WCC::Contentful::LinkVisitor.new(entry, :Link, depth: depth - 1).map! do |val|
           resolve_link(val)
         end
       end

--- a/wcc-contentful/lib/wcc/contentful/store/factory.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/factory.rb
@@ -75,6 +75,7 @@ module WCC::Contentful::Store
           middleware, params, configure_proc = middleware_config
           middleware_options = options.merge((params || []).extract_options!)
           middleware = middleware.call(memo, *params, **middleware_options)
+          services.inject_into(middleware, except: %i[store preview_store])
           middleware&.instance_exec(&configure_proc) if configure_proc
           middleware || memo
         end
@@ -154,12 +155,7 @@ module WCC::Contentful::Store
         end
 
       # Inject services into the custom store class
-      (WCC::Contentful::SERVICES - %i[store preview_store]).each do |s|
-        next unless store.respond_to?("#{s}=")
-
-        store.public_send("#{s}=",
-          services.public_send(s))
-      end
+      services.inject_into(store, except: %i[store preview_store])
 
       store
     end

--- a/wcc-contentful/lib/wcc/contentful/store/query.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/query.rb
@@ -108,7 +108,7 @@ module WCC::Contentful::Store
       includes = row.try(:includes) || row.try(:[], 1)
       return entry unless entry && depth && depth > 0
 
-      WCC::Contentful::LinkVisitor.new(entry, :Link, :Asset,
+      WCC::Contentful::LinkVisitor.new(entry, :Link,
         # Walk all the links except for the leaf nodes
         depth: depth - 1).map! do |val|
         resolve_link(val, includes)

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/basic_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/basic_store.rb
@@ -130,24 +130,6 @@ RSpec.shared_examples 'basic store' do
     JSON
   end
 
-  before do
-    allow(WCC::Contentful).to receive(:types)
-      .and_return({
-        'root' => double(fields: {
-          'name' => double(name: 'name', type: :String, array: false),
-          'link' => double(name: 'link', type: :Link, array: false),
-          'links' => double(name: 'links', type: :Link, array: true)
-        }),
-        'shallow' => double(fields: {
-          'name' => double(name: 'name', type: :String, array: false)
-        }),
-        'deep' => double(fields: {
-          'name' => double(name: 'name', type: :String, array: false),
-          'subLink' => double(name: 'subLink', type: :Link, array: false)
-        })
-      })
-  end
-
   describe '#set/#find' do
     describe 'ensures that the stored value is of type Hash' do
       it 'should not raise an error if value is a Hash' do

--- a/wcc-contentful/lib/wcc/contentful/sync_engine.rb
+++ b/wcc-contentful/lib/wcc/contentful/sync_engine.rb
@@ -49,7 +49,6 @@ module WCC::Contentful
         end
 
         @store = store
-        @state = read_state if should_sync?
       end
       if state
         @state = token_wrapper_factory(state)

--- a/wcc-contentful/lib/wcc/contentful/test/attributes.rb
+++ b/wcc-contentful/lib/wcc/contentful/test/attributes.rb
@@ -31,10 +31,6 @@ module WCC::Contentful::Test::Attributes
     ##
     # Get a hash of default values for all attributes unique to the given Contentful model.
     def defaults(const)
-      unless const < WCC::Contentful::Model
-        raise ArgumentError, "#{const} is not a subclass of WCC::Contentful::Model"
-      end
-
       const.content_type_definition.fields.each_with_object({}) do |(name, f), h|
         h[name.to_sym] = h[name.underscore.to_sym] = default_value(f)
       end

--- a/wcc-contentful/lib/wcc/contentful/test/double.rb
+++ b/wcc-contentful/lib/wcc/contentful/test/double.rb
@@ -7,8 +7,10 @@ module WCC::Contentful::Test::Double
   # Builds a rspec double of the Contentful model for the given content_type.
   # All attributes that are known to be required fields on the content type
   # will return a default value based on the field type.
-  def contentful_double(content_type, **attrs)
-    const = WCC::Contentful::Model.resolve_constant(content_type)
+  def contentful_double(const, **attrs)
+    unless const.respond_to?(:content_type_definition)
+      const = WCC::Contentful::Model.resolve_constant(const.to_s)
+    end
     attrs.symbolize_keys!
 
     bad_attrs = attrs.reject { |a| const.instance_methods.include?(a) }

--- a/wcc-contentful/lib/wcc/contentful/test/factory.rb
+++ b/wcc-contentful/lib/wcc/contentful/test/factory.rb
@@ -7,8 +7,10 @@ module WCC::Contentful::Test::Factory
   # Builds a in-memory instance of the Contentful model for the given content_type.
   # All attributes that are known to be required fields on the content type
   # will return a default value based on the field type.
-  def contentful_create(content_type, context = nil, **attrs)
-    const = WCC::Contentful::Model.resolve_constant(content_type.to_s)
+  def contentful_create(const, context = nil, **attrs)
+    unless const.respond_to?(:content_type_definition)
+      const = WCC::Contentful::Model.resolve_constant(const.to_s)
+    end
     attrs = attrs.transform_keys { |a| a.to_s.camelize(:lower) }
 
     id = attrs.delete('id')

--- a/wcc-contentful/spec/fixtures/contentful/blog-contentful-schema.json
+++ b/wcc-contentful/spec/fixtures/contentful/blog-contentful-schema.json
@@ -1,0 +1,1568 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "id": "blogPost",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "BlogPost",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "subtitle",
+          "name": "Subtitle",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "summary",
+          "name": "Summary",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "regexp": {
+                "pattern": "^(\\/|(?:\\/[a-z\\d](?:[a-z\\d_\\-]|(?:\\%[\\dA-Z]{2}))*)+)$"
+              },
+              "message": "The slug must look like the path part of a URL and begin with a forward slash, example: '/my-blog-post-slug'.  It must also be all lower-case."
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "publishAt",
+          "name": "Publish At",
+          "type": "Date",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "flags",
+          "name": "Flags",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": [
+                  "hide from internal search"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "heroImage",
+          "name": "Hero Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "linkMimetypeGroup": [
+                "image"
+              ]
+            },
+            {
+              "assetImageDimensions": {
+                "width": {
+                  "min": 1920,
+                  "max": 1920
+                },
+                "height": {
+                  "min": 1080,
+                  "max": 1080
+                }
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "thumbnailImage",
+          "name": "Thumbnail Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkMimetypeGroup": [
+                "image"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "author",
+          "name": "Author",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "sections",
+          "name": "Sections",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "sectionBlockText",
+                  "section-pull-quote",
+                  "section-scripture-quote",
+                  "section-video-embed"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "metadata",
+          "name": "Metadata",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkContentType": [
+                "pageMetadata"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "canonicalProperty",
+          "name": "Canonical Property",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "linkContentType": [
+                "property"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "categories",
+          "name": "Categories",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "category"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "tags",
+          "name": "Tags",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "tag"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "primaryPublishingTarget",
+          "name": "Primary Publishing Target",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkContentType": [
+                "publishingTarget"
+              ]
+            }
+          ],
+          "disabled": true,
+          "omitted": true,
+          "linkType": "Entry"
+        },
+        {
+          "id": "publishingTargets",
+          "name": "Publishing Targets",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": true,
+          "omitted": true,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "publishingTarget"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "buildStatus",
+          "name": "Build Status",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": true,
+          "omitted": false
+        },
+        {
+          "id": "relatedTo",
+          "name": "Related To",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "blogPost"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "category",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Category",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "key",
+          "name": "Key",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "regexp": {
+                "pattern": "^[a-z][a-z0-9\\-_]+$",
+                "flags": null
+              },
+              "message": "The key must be all lower-case and start with a letter.  It can contain underscores."
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "errorNotificationEmailList",
+          "name": "Error Notification Email List",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "regexp": {
+                  "pattern": "^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$"
+                },
+                "message": "Must be an email address"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "collection",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Collection",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "key",
+          "name": "Key",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "regexp": {
+                "pattern": "^[a-z]+(\\-[a-z0-9]+)*$",
+                "flags": null
+              },
+              "message": "The key must be lower-case and can only include letters, numbers, and dashes '-'."
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "posts",
+          "name": "Posts",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "blogPost"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "heroImage",
+          "name": "Hero Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkMimetypeGroup": [
+                "image"
+              ]
+            },
+            {
+              "assetImageDimensions": {
+                "width": {
+                  "min": 1920,
+                  "max": 1920
+                },
+                "height": {
+                  "min": 1080,
+                  "max": 1080
+                }
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "migrationHistory",
+        "type": "ContentType"
+      },
+      "displayField": "migrationName",
+      "name": "Migration History",
+      "description": "System Type - Do Not Modify",
+      "fields": [
+        {
+          "id": "migrationName",
+          "name": "Migration Name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "started",
+          "name": "Started",
+          "type": "Date",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "completed",
+          "name": "Completed",
+          "type": "Date",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "detail",
+          "name": "Detail",
+          "type": "Object",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "pageMetadata",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Page Metadata",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "metaDescription",
+          "name": "Meta Description",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "metaKeywords",
+          "name": "Meta Keywords",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "metaFlag",
+          "name": "Meta Flag",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": [
+                  "no-follow",
+                  "no-index"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "canonicalLink",
+          "name": "Canonical Link",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "regexp": {
+                "pattern": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$"
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "property",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Property",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "key",
+          "name": "Key",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "in": [
+                "paper_signs",
+                "watermark_resources",
+                "theporch-app",
+                "reengage",
+                "regeneration",
+                "test"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "categories",
+          "name": "Categories",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "category"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "acceptedTags",
+          "name": "Accepted Tags",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "tag"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "canonicalUrlTemplate",
+          "name": "Canonical URL Template",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "regexp": {
+                "pattern": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$"
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "webhookUrl",
+          "name": "Webhook URL",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "publishingTarget",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Publishing Target",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "key",
+          "name": "Key",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "in": [
+                "watermark_resources",
+                "paper_signs",
+                "reengage.org"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "webhookUrl",
+          "name": "Webhook URL",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "canonicalUrlTemplate",
+          "name": "Canonical URL Template",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "regexp": {
+                "pattern": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$"
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "section-pull-quote",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Section: Pull Quote",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "anchorId",
+          "name": "Anchor ID",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "quoteText",
+          "name": "Quote Text",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "section-scripture-quote",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Section: Scripture Quote",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "anchorId",
+          "name": "Anchor ID",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "keyVerse",
+          "name": "Key Verse",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "keyVerseContext",
+          "name": "Key Verse Context",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "section-video-embed",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Section: Video Embed",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "anchorId",
+          "name": "Anchor ID",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "embedCode",
+          "name": "Embed Code",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "sectionBlockText",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Section: Block Text",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "anchorId",
+          "name": "Anchor ID",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "text",
+          "name": "Text",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "tag",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Tag",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "key",
+          "name": "Key",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "regexp": {
+                "pattern": "^[a-z][a-z0-9\\-_]+$",
+                "flags": null
+              },
+              "message": "A tag key must be all lower case and start with a letter.  It can have hyphens or underscores."
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "blogPost",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "author",
+          "settings": {
+            "space": "hw5pse7y1ojx",
+            "display": "${firstName} ${lastName}",
+            "accessToken": "riHZ3gFYMgocp_V20x40T5C_Dfe_MWaFJstIzbc-Q34",
+            "contentType": "person"
+          },
+          "widgetId": "cross-space-link"
+        },
+        {
+          "fieldId": "buildStatus",
+          "widgetId": "15wvANEluAVvFw2AjjdQ4S"
+        },
+        {
+          "fieldId": "canonicalProperty",
+          "settings": {
+            "helpText": "The Blog Post must have a Canonical property that all other properties link back to for SEO purposes."
+          },
+          "widgetId": "entryLinkEditor"
+        },
+        {
+          "fieldId": "categories",
+          "settings": {
+            "helpText": "Pick the categories that this blog post should be listed under.  If a property subscribes to one of these categories, then the blog post will be shown on that website.",
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "flags",
+          "widgetId": "checkbox"
+        },
+        {
+          "fieldId": "heroImage",
+          "settings": {
+            "helpText": "The image must be 16x9 aspect ratio (1920x1080)"
+          },
+          "widgetId": "assetLinkEditor"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "metadata",
+          "widgetId": "entryLinkEditor"
+        },
+        {
+          "fieldId": "primaryPublishingTarget",
+          "settings": {
+            "helpText": "Deprecated (this will be removed soon)"
+          },
+          "widgetId": "entryCardEditor"
+        },
+        {
+          "fieldId": "publishAt",
+          "widgetId": "datePicker"
+        },
+        {
+          "fieldId": "publishingTargets",
+          "settings": {
+            "helpText": "Deprecated (this will be removed soon)",
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "relatedTo",
+          "settings": {
+            "bulkEditing": false,
+            "showLinkEntityAction": true,
+            "showCreateEntityAction": true
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "sections",
+          "settings": {
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "slug",
+          "widgetId": "slugEditor"
+        },
+        {
+          "fieldId": "subtitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "summary",
+          "widgetId": "multipleLine"
+        },
+        {
+          "fieldId": "tags",
+          "settings": {
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "thumbnailImage",
+          "settings": {
+            "helpText": "The image must be 1x1 (square) aspect ratio"
+          },
+          "widgetId": "assetLinkEditor"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "category",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "errorNotificationEmailList",
+          "widgetId": "tagEditor"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "key",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "settings": {
+            "helpText": "The Title is displayed in the category listing on a site, ex. on the search filters."
+          },
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "collection",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "heroImage",
+          "widgetId": "assetLinkEditor"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "key",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "posts",
+          "settings": {
+            "bulkEditing": false,
+            "showLinkEntityAction": true,
+            "showCreateEntityAction": true
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "migrationHistory",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "completed"
+        },
+        {
+          "fieldId": "detail"
+        },
+        {
+          "fieldId": "migrationName"
+        },
+        {
+          "fieldId": "started"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "pageMetadata",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "canonicalLink",
+          "settings": {
+            "helpText": "The Canonical URL tells Google where the primary version of this blog post lives.  Only set this field if the blog post's canonical location is not in one of the Publishing Targets."
+          },
+          "widgetId": "urlEditor"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "metaDescription",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "metaFlag",
+          "settings": {
+            "helpText": "No Index also removes page from sitemap"
+          },
+          "widgetId": "checkbox"
+        },
+        {
+          "fieldId": "metaKeywords",
+          "settings": {
+            "helpText": "Comma separated list of keywords to be used by internal and external search engines."
+          },
+          "widgetId": "multipleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "property",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "acceptedTags",
+          "settings": {
+            "helpText": "Select the blog tags which are relevant to this site.",
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "canonicalUrlTemplate",
+          "settings": {
+            "helpText": "The Canonical URL template is evaluated to determine the canonical URL of a blog that is primarily published to this property."
+          },
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "categories",
+          "settings": {
+            "helpText": "Link the categories that should be published to this site.",
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "key",
+          "widgetId": "dropdown"
+        },
+        {
+          "fieldId": "webhookUrl",
+          "settings": {
+            "helpText": "The system will execute a POST to this URL with the contents of any blogs that have changed."
+          },
+          "widgetId": "urlEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "publishingTarget",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "canonicalUrlTemplate",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "key",
+          "widgetId": "dropdown"
+        },
+        {
+          "fieldId": "webhookUrl",
+          "settings": {
+            "helpText": "The system will execute a POST to this URL with the contents of any blogs that have changed."
+          },
+          "widgetId": "urlEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "section-pull-quote",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "anchorId",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "quoteText",
+          "widgetId": "multipleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "section-scripture-quote",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "anchorId",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "keyVerse",
+          "settings": {
+            "helpText": "Example: Colossians 3:23"
+          },
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "keyVerseContext",
+          "settings": {
+            "helpText": "Example: Colossians 3:21-26"
+          },
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "section-video-embed",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "anchorId",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "embedCode",
+          "settings": {
+            "helpText": "Copy and paste the embed HTML here"
+          },
+          "widgetId": "multipleLine"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "sectionBlockText",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "anchorId",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "text",
+          "widgetId": "markdown"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "tag",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "key",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "settings": {
+            "helpText": "The Title is displayed to the end user, for example in the list of tags for a blog post or on the search filters."
+          },
+          "widgetId": "singleLine"
+        }
+      ]
+    }
+  ]
+}

--- a/wcc-contentful/spec/fixtures/contentful/blog-contentful-schema.json
+++ b/wcc-contentful/spec/fixtures/contentful/blog-contentful-schema.json
@@ -1067,7 +1067,6 @@
           "settings": {
             "space": "hw5pse7y1ojx",
             "display": "${firstName} ${lastName}",
-            "accessToken": "riHZ3gFYMgocp_V20x40T5C_Dfe_MWaFJstIzbc-Q34",
             "contentType": "person"
           },
           "widgetId": "cross-space-link"

--- a/wcc-contentful/spec/spec_helper.rb
+++ b/wcc-contentful/spec/spec_helper.rb
@@ -42,6 +42,8 @@ RSpec.shared_context 'Contentful config' do
       end
     end
     WCC::Contentful::Model.class_variable_get('@@registry').clear
+
+    WCC::Contentful::Model.instance_variable_set('@schema', nil)
     Wisper.clear
   end
 end

--- a/wcc-contentful/spec/spec_helper.rb
+++ b/wcc-contentful/spec/spec_helper.rb
@@ -44,6 +44,8 @@ RSpec.shared_context 'Contentful config' do
     WCC::Contentful::Model.class_variable_get('@@registry').clear
 
     WCC::Contentful::Model.instance_variable_set('@schema', nil)
+    WCC::Contentful::Model.instance_variable_set('@services', nil)
+    WCC::Contentful::Model.instance_variable_set('@configuration', nil)
     Wisper.clear
   end
 end

--- a/wcc-contentful/spec/support/fixtures_helper.rb
+++ b/wcc-contentful/spec/support/fixtures_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module FixturesHelper
-  def fixture_path(file_name)
+  def path_to_fixture(file_name)
     File.join(fixture_root, file_name)
   end
 
   def load_fixture(file_name)
-    file = fixture_path(file_name)
+    file = path_to_fixture(file_name)
     return unless File.exist?(file)
 
     File.read(file)

--- a/wcc-contentful/spec/support/fixtures_helper.rb
+++ b/wcc-contentful/spec/support/fixtures_helper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module FixturesHelper
+  def fixture_path(file_name)
+    File.join(fixture_root, file_name)
+  end
+
   def load_fixture(file_name)
-    file = File.join(fixture_root, file_name)
+    file = fixture_path(file_name)
     return unless File.exist?(file)
 
     File.read(file)

--- a/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
@@ -280,6 +280,11 @@ RSpec.describe WCC::Contentful::Configuration do
       expect(instrumentation).to receive(:instrument) { |_, _, &block| block.call }
         .at_least(:once)
 
+      WCC::Contentful::Model.configure(
+        config,
+        services: WCC::Contentful::Services.instance
+      )
+
       # act
       WCC::Contentful::Model.find('test')
     end

--- a/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe WCC::Contentful::Configuration do
   subject(:config) {
     WCC::Contentful::Configuration.new.tap do |config|
+      config.schema_file = path_to_fixture('contentful/contentful-schema.json')
       config.space = contentful_space_id
       config.access_token = contentful_access_token
       config.management_token = contentful_management_token

--- a/wcc-contentful/spec/wcc/contentful/events_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/events_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe WCC::Contentful::Events do
     it 'rebroadcasts sync engine events' do
       client = double('client')
       sync_engine = WCC::Contentful::SyncEngine.new(state: 'start-token', client: client)
-      allow(WCC::Contentful::Services.instance).to receive(:sync_engine)
-        .and_return(sync_engine)
+      services = double(
+        client: client,
+        sync_engine: sync_engine
+      )
+      allow(WCC::Contentful::Services).to receive(:instance)
+        .and_return(services)
 
       allow(client).to receive(:sync)
         .and_return(
@@ -38,8 +42,9 @@ RSpec.describe WCC::Contentful::Events do
       subscriber = double('subsc 2')
       expect(subscriber).to receive(:Entry)
 
-      allow(WCC::Contentful::Services.instance).to receive(:sync_engine)
-        .and_return(double('sync_engine', subscribe: nil))
+      sync_engine = double('sync_engine', subscribe: nil)
+      allow(WCC::Contentful::Services).to receive(:instance)
+        .and_return(double(sync_engine: sync_engine))
 
       instance = WCC::Contentful::Events.new
       instance.subscribe(subscriber)

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -12,6 +12,483 @@ RSpec.describe WCC::Contentful::ModelAPI do
   }
 
   before do
+    reset_test_namespace!
+  end
+
+  context 'when configured' do
+    before do
+      TestNamespace.configure(services: services) do |config|
+        config.schema_file = path_to_fixture('contentful/blog-contentful-schema.json')
+      end
+    end
+
+    it 'builds classes under namespace' do
+      expect(TestNamespace.constants(false).sort).to eq(
+        %i[
+          Asset
+          BlogPost
+          Category
+          Collection
+          MigrationHistory
+          PageMetadata
+          Property
+          PublishingTarget
+          SectionBlockText
+          SectionPullQuote
+          SectionScriptureQuote
+          SectionVideoEmbed
+          Tag
+        ]
+      )
+    end
+
+    it 'resolves json blobs' do
+      # act
+      migration = TestNamespace::MigrationHistory.new({
+        'sys' => {
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'migrationHistory'
+            }
+          }
+        },
+        'fields' => {
+          'detail' => {
+            'en-US' => [
+              {
+                'intent' => {
+                  'intents' => [
+                    {
+                      'meta' => {
+                        'callsite' => {
+                          'file' =>
+                            './jtj-com/db/migrate/20180219160530_test_migration.ts',
+                          'line' => 3
+                        },
+                        'contentTypeInstanceId' => 'contentType/dog/0'
+                      },
+                      'type' => 'contentType/create',
+                      'payload' => {
+                        'contentTypeId' => 'dog'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      # assert
+      expect(migration.detail).to be_instance_of(Array)
+      expect(migration.detail[0]).to be_instance_of(OpenStruct)
+      expect(migration.detail.dig(0, 'intent', 'intents')).to include(
+        {
+          'meta' => {
+            'callsite' => {
+              'file' =>
+                './jtj-com/db/migrate/20180219160530_test_migration.ts',
+              'line' => 3
+            },
+            'contentTypeInstanceId' => 'contentType/dog/0'
+          },
+          'type' => 'contentType/create',
+          'payload' => {
+            'contentTypeId' => 'dog'
+          }
+        }
+      )
+    end
+
+    # Note: see code comment inside model_builder.rb for why we do not parse DateTime objects
+    it 'does not parse date times' do
+      # act
+      post = TestNamespace::BlogPost.new({
+        'sys' => {
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'publishAt' => {
+            'en-US' => '2021-01-01'
+          }
+        }
+      })
+
+      # assert
+      expect(post.publish_at).to be_a String
+      expect(post.publish_at).to eq('2021-01-01')
+    end
+
+    it 'resolves linked types' do
+      # act
+      post = TestNamespace::BlogPost.new({
+        'sys' => {
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'sections' => {
+            'en-US' => [
+              {
+                'sys' => {
+                  'type' => 'Entry',
+                  'contentType' => {
+                    'sys' => {
+                      'id' => 'sectionBlockText'
+                    }
+                  }
+                },
+                'fields' => {
+                  'text' => {
+                    'en-US' => 'Lorem Ipsum Dolor Sit Amet'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      # assert
+      expect(post.sections[0]).to be_instance_of(TestNamespace::SectionBlockText)
+      expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
+    end
+
+    it 'inherited class resolves linked types' do
+      class MyBlogPost < TestNamespace::BlogPost
+      end
+
+      class MyBlockText < TestNamespace::SectionBlockText
+      end
+
+      # act
+      post = MyBlogPost.new({
+        'sys' => {
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'sections' => {
+            'en-US' => [
+              {
+                'sys' => {
+                  'type' => 'Entry',
+                  'contentType' => {
+                    'sys' => {
+                      'id' => 'sectionBlockText'
+                    }
+                  }
+                },
+                'fields' => {
+                  'text' => {
+                    'en-US' => 'Lorem Ipsum Dolor Sit Amet'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      # assert
+      expect(post.sections[0]).to be_instance_of(MyBlockText)
+      expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
+    end
+
+    it 'finds models by ID' do
+      allow(store).to receive(:find)
+        .with('1234', anything)
+        .and_return({
+          'sys' => {
+            'id' => '1234',
+            'type' => 'Entry',
+            'contentType' => {
+              'sys' => {
+                'id' => 'blogPost'
+              }
+            }
+          },
+          'fields' => {
+            'title' => {
+              'en-US' => 'Lorem Ipsum'
+            }
+          }
+        })
+
+      # act
+      entry = TestNamespace.find('1234')
+
+      # assert
+      expect(entry).to be_a(TestNamespace::BlogPost)
+      expect(entry.id).to eq('1234')
+      expect(entry.title).to eq('Lorem Ipsum')
+    end
+
+    it 'finds by ID on derived class' do
+      allow(store).to receive(:find)
+        .with('1234', anything)
+        .and_return({
+          'sys' => {
+            'id' => '1234',
+            'type' => 'Entry',
+            'contentType' => {
+              'sys' => {
+                'id' => 'blogPost'
+              }
+            }
+          },
+          'fields' => {
+            'title' => {
+              'en-US' => 'Lorem Ipsum'
+            }
+          }
+        })
+
+      # act
+      entry = TestNamespace::BlogPost.find('1234')
+
+      # assert
+      expect(entry).to be_a(TestNamespace::BlogPost)
+      expect(entry.id).to eq('1234')
+      expect(entry.title).to eq('Lorem Ipsum')
+    end
+
+    it 'finds by ID on subclass' do
+      allow(store).to receive(:find)
+        .with('1234', anything)
+        .and_return({
+          'sys' => {
+            'id' => '1234',
+            'type' => 'Entry',
+            'contentType' => {
+              'sys' => {
+                'id' => 'blogPost'
+              }
+            }
+          },
+          'fields' => {
+            'title' => {
+              'en-US' => 'Lorem Ipsum'
+            }
+          }
+        })
+
+      # act
+      entry = TestNamespace::BlogPost.find('1234')
+
+      # assert
+      expect(entry).to be_a(TestNamespace::BlogPost)
+      expect(entry.id).to eq('1234')
+      expect(entry.title).to eq('Lorem Ipsum')
+    end
+
+    it 'instruments find' do
+      allow(store).to receive(:find)
+      # act
+      expect {
+        TestNamespace::BlogPost.find('1234')
+      }.to instrument('find.model.contentful.wcc')
+    end
+
+    it 'subclass instruments find using configured instrumentation' do
+      class MyBlogPost2 < TestNamespace::BlogPost
+      end
+
+      instrumentation = double
+      allow(instrumentation).to receive(:instrument)
+      allow(services).to receive(:instrumentation)
+        .and_return(instrumentation)
+
+      allow(store).to receive(:find)
+
+      # act
+      MyBlogPost2.find('1234')
+
+      expect(instrumentation).to have_received(:instrument)
+        .with('find.model.contentful.wcc',
+          content_type: 'blogPost', id: '1234', options: {})
+    end
+
+    it 'finds all by content type' do
+      allow(store).to receive(:find_all)
+        .with(content_type: 'blogPost', options: {})
+        .and_return([
+          {
+            'sys' => {
+              'id' => '1234',
+              'type' => 'Entry',
+              'contentType' => {
+                'sys' => {
+                  'id' => 'blogPost'
+                }
+              }
+            }
+          },
+          {
+            'sys' => {
+              'id' => '5678',
+              'type' => 'Entry',
+              'contentType' => {
+                'sys' => {
+                  'id' => 'blogPost'
+                }
+              }
+            }
+          },
+          {
+            'sys' => {
+              'id' => '9012',
+              'type' => 'Entry',
+              'contentType' => {
+                'sys' => {
+                  'id' => 'blogPost'
+                }
+              }
+            }
+          }
+        ].lazy)
+
+      # act
+      posts = TestNamespace::BlogPost.find_all
+
+      # assert
+      expect(posts.map(&:id).sort).to eq(
+        %w[
+          1234
+          5678
+          9012
+        ]
+      )
+    end
+
+    it 'finds single item with filter' do
+      allow(store).to receive(:find_by)
+        .with(content_type: 'blogPost', filter: { 'slug' => 'mister_roboto' }, options: {})
+        .and_return(
+          {
+            'sys' => {
+              'id' => '1234',
+              'type' => 'Entry',
+              'contentType' => {
+                'sys' => {
+                  'id' => 'blogPost'
+                }
+              }
+            }
+          }
+        )
+
+      # act
+      post = TestNamespace::BlogPost.find_by(slug: 'mister_roboto')
+
+      # assert
+      expect(post.id).to eq('1234')
+    end
+
+    it 'calls into store to resolve linked types' do
+      allow(store).to receive(:find)
+        .with('blockText1234', anything)
+        .and_return(
+          {
+            'sys' => {
+              'type' => 'Entry',
+              'contentType' => {
+                'sys' => {
+                  'id' => 'sectionBlockText'
+                }
+              }
+            },
+            'fields' => {
+              'text' => {
+                'en-US' => 'Lorem Ipsum Dolor Sit Amet'
+              }
+            }
+          }
+        )
+
+      # act
+      post = TestNamespace::BlogPost.new({
+        'sys' => {
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'sections' => {
+            'en-US' => [
+              {
+                'sys' => {
+                  'type' => 'Link',
+                  'linkType' => 'Entry',
+                  'id' => 'blockText1234'
+                }
+              }
+            ]
+          }
+        }
+      })
+
+      # assert
+      expect(post.sections[0]).to be_a TestNamespace::SectionBlockText
+      expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
+    end
+  end
+
+  describe '.configure' do
+    it 'applies custom instrumentation adapter to the whole stack', focus: true do
+      instrumentation = double('instrumentation')
+
+      TestNamespace.configure do |config|
+        config.schema_file = path_to_fixture('contentful/blog-contentful-schema.json')
+        config.instrumentation_adapter = instrumentation
+      end
+
+      stub_request(:get, /\/(entries|assets)\/test/)
+        .to_return(status: 404)
+
+      events = []
+      allow(instrumentation).to receive(:instrument) do |name, _, &block|
+        events << name
+        block.call
+      end
+
+      expect(ActiveSupport::Notifications).to_not receive(:instrument)
+      expect(instrumentation).to receive(:instrument)
+        .at_least(:once)
+
+      # act
+      TestNamespace::BlogPost.find('test')
+
+      expect(events).to eq(
+        [
+          'find.model.contentful.wcc',
+          'find.store.contentful.wcc',
+          'entries.simpleclient.contentful.wcc',
+          'get_http.simpleclient.contentful.wcc'
+        ]
+      )
+    end
+  end
+
+  def reset_test_namespace!
     consts = TestNamespace.constants(false).map(&:to_s).uniq
     consts.each do |c|
       begin
@@ -24,439 +501,6 @@ RSpec.describe WCC::Contentful::ModelAPI do
     TestNamespace.instance_variable_set('@schema', nil)
     TestNamespace.instance_variable_set('@services', nil)
     TestNamespace.instance_variable_set('@configuration', nil)
-
-    TestNamespace.configure(services: services) do |config|
-      config.schema_file = path_to_fixture('contentful/blog-contentful-schema.json')
-    end
-  end
-
-  it 'builds classes under namespace' do
-    expect(TestNamespace.constants(false).sort).to eq(
-      %i[
-        Asset
-        BlogPost
-        Category
-        Collection
-        MigrationHistory
-        PageMetadata
-        Property
-        PublishingTarget
-        SectionBlockText
-        SectionPullQuote
-        SectionScriptureQuote
-        SectionVideoEmbed
-        Tag
-      ]
-    )
-  end
-
-  it 'resolves json blobs' do
-    # act
-    migration = TestNamespace::MigrationHistory.new({
-      'sys' => {
-        'type' => 'Entry',
-        'contentType' => {
-          'sys' => {
-            'id' => 'migrationHistory'
-          }
-        }
-      },
-      'fields' => {
-        'detail' => {
-          'en-US' => [
-            {
-              'intent' => {
-                'intents' => [
-                  {
-                    'meta' => {
-                      'callsite' => {
-                        'file' =>
-                          './jtj-com/db/migrate/20180219160530_test_migration.ts',
-                        'line' => 3
-                      },
-                      'contentTypeInstanceId' => 'contentType/dog/0'
-                    },
-                    'type' => 'contentType/create',
-                    'payload' => {
-                      'contentTypeId' => 'dog'
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
-    })
-
-    # assert
-    expect(migration.detail).to be_instance_of(Array)
-    expect(migration.detail[0]).to be_instance_of(OpenStruct)
-    expect(migration.detail.dig(0, 'intent', 'intents')).to include(
-      {
-        'meta' => {
-          'callsite' => {
-            'file' =>
-              './jtj-com/db/migrate/20180219160530_test_migration.ts',
-            'line' => 3
-          },
-          'contentTypeInstanceId' => 'contentType/dog/0'
-        },
-        'type' => 'contentType/create',
-        'payload' => {
-          'contentTypeId' => 'dog'
-        }
-      }
-    )
-  end
-
-  # Note: see code comment inside model_builder.rb for why we do not parse DateTime objects
-  it 'does not parse date times' do
-    # act
-    post = TestNamespace::BlogPost.new({
-      'sys' => {
-        'type' => 'Entry',
-        'contentType' => {
-          'sys' => {
-            'id' => 'blogPost'
-          }
-        }
-      },
-      'fields' => {
-        'publishAt' => {
-          'en-US' => '2021-01-01'
-        }
-      }
-    })
-
-    # assert
-    expect(post.publish_at).to be_a String
-    expect(post.publish_at).to eq('2021-01-01')
-  end
-
-  it 'resolves linked types' do
-    # act
-    post = TestNamespace::BlogPost.new({
-      'sys' => {
-        'type' => 'Entry',
-        'contentType' => {
-          'sys' => {
-            'id' => 'blogPost'
-          }
-        }
-      },
-      'fields' => {
-        'sections' => {
-          'en-US' => [
-            {
-              'sys' => {
-                'type' => 'Entry',
-                'contentType' => {
-                  'sys' => {
-                    'id' => 'sectionBlockText'
-                  }
-                }
-              },
-              'fields' => {
-                'text' => {
-                  'en-US' => 'Lorem Ipsum Dolor Sit Amet'
-                }
-              }
-            }
-          ]
-        }
-      }
-    })
-
-    # assert
-    expect(post.sections[0]).to be_instance_of(TestNamespace::SectionBlockText)
-    expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
-  end
-
-  it 'inherited class resolves linked types' do
-    class MyBlogPost < TestNamespace::BlogPost
-    end
-
-    class MyBlockText < TestNamespace::SectionBlockText
-    end
-
-    # act
-    post = MyBlogPost.new({
-      'sys' => {
-        'type' => 'Entry',
-        'contentType' => {
-          'sys' => {
-            'id' => 'blogPost'
-          }
-        }
-      },
-      'fields' => {
-        'sections' => {
-          'en-US' => [
-            {
-              'sys' => {
-                'type' => 'Entry',
-                'contentType' => {
-                  'sys' => {
-                    'id' => 'sectionBlockText'
-                  }
-                }
-              },
-              'fields' => {
-                'text' => {
-                  'en-US' => 'Lorem Ipsum Dolor Sit Amet'
-                }
-              }
-            }
-          ]
-        }
-      }
-    })
-
-    # assert
-    expect(post.sections[0]).to be_instance_of(MyBlockText)
-    expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
-  end
-
-  it 'finds models by ID' do
-    allow(store).to receive(:find)
-      .with('1234', anything)
-      .and_return({
-        'sys' => {
-          'id' => '1234',
-          'type' => 'Entry',
-          'contentType' => {
-            'sys' => {
-              'id' => 'blogPost'
-            }
-          }
-        },
-        'fields' => {
-          'title' => {
-            'en-US' => 'Lorem Ipsum'
-          }
-        }
-      })
-
-    # act
-    entry = TestNamespace.find('1234')
-
-    # assert
-    expect(entry).to be_a(TestNamespace::BlogPost)
-    expect(entry.id).to eq('1234')
-    expect(entry.title).to eq('Lorem Ipsum')
-  end
-
-  it 'finds by ID on derived class' do
-    allow(store).to receive(:find)
-      .with('1234', anything)
-      .and_return({
-        'sys' => {
-          'id' => '1234',
-          'type' => 'Entry',
-          'contentType' => {
-            'sys' => {
-              'id' => 'blogPost'
-            }
-          }
-        },
-        'fields' => {
-          'title' => {
-            'en-US' => 'Lorem Ipsum'
-          }
-        }
-      })
-
-    # act
-    entry = TestNamespace::BlogPost.find('1234')
-
-    # assert
-    expect(entry).to be_a(TestNamespace::BlogPost)
-    expect(entry.id).to eq('1234')
-    expect(entry.title).to eq('Lorem Ipsum')
-  end
-
-  it 'finds by ID on subclass' do
-    allow(store).to receive(:find)
-      .with('1234', anything)
-      .and_return({
-        'sys' => {
-          'id' => '1234',
-          'type' => 'Entry',
-          'contentType' => {
-            'sys' => {
-              'id' => 'blogPost'
-            }
-          }
-        },
-        'fields' => {
-          'title' => {
-            'en-US' => 'Lorem Ipsum'
-          }
-        }
-      })
-
-    # act
-    entry = TestNamespace::BlogPost.find('1234')
-
-    # assert
-    expect(entry).to be_a(TestNamespace::BlogPost)
-    expect(entry.id).to eq('1234')
-    expect(entry.title).to eq('Lorem Ipsum')
-  end
-
-  it 'instruments find' do
-    allow(store).to receive(:find)
-    # act
-    expect {
-      TestNamespace::BlogPost.find('1234')
-    }.to instrument('find.model.contentful.wcc')
-  end
-
-  it 'subclass instruments find using configured instrumentation' do
-    class MyBlogPost2 < TestNamespace::BlogPost
-    end
-
-    instrumentation = double
-    allow(instrumentation).to receive(:instrument)
-    allow(services).to receive(:instrumentation)
-      .and_return(instrumentation)
-
-    allow(store).to receive(:find)
-
-    # act
-    MyBlogPost2.find('1234')
-
-    expect(instrumentation).to have_received(:instrument)
-      .with('find.model.contentful.wcc',
-        content_type: 'blogPost', id: '1234', options: {})
-  end
-
-  it 'finds all by content type' do
-    allow(store).to receive(:find_all)
-      .with(content_type: 'blogPost', options: {})
-      .and_return([
-        {
-          'sys' => {
-            'id' => '1234',
-            'type' => 'Entry',
-            'contentType' => {
-              'sys' => {
-                'id' => 'blogPost'
-              }
-            }
-          }
-        },
-        {
-          'sys' => {
-            'id' => '5678',
-            'type' => 'Entry',
-            'contentType' => {
-              'sys' => {
-                'id' => 'blogPost'
-              }
-            }
-          }
-        },
-        {
-          'sys' => {
-            'id' => '9012',
-            'type' => 'Entry',
-            'contentType' => {
-              'sys' => {
-                'id' => 'blogPost'
-              }
-            }
-          }
-        }
-      ].lazy)
-
-    # act
-    posts = TestNamespace::BlogPost.find_all
-
-    # assert
-    expect(posts.map(&:id).sort).to eq(
-      %w[
-        1234
-        5678
-        9012
-      ]
-    )
-  end
-
-  it 'finds single item with filter' do
-    allow(store).to receive(:find_by)
-      .with(content_type: 'blogPost', filter: { 'slug' => 'mister_roboto' }, options: {})
-      .and_return(
-        {
-          'sys' => {
-            'id' => '1234',
-            'type' => 'Entry',
-            'contentType' => {
-              'sys' => {
-                'id' => 'blogPost'
-              }
-            }
-          }
-        }
-      )
-
-    # act
-    post = TestNamespace::BlogPost.find_by(slug: 'mister_roboto')
-
-    # assert
-    expect(post.id).to eq('1234')
-  end
-
-  it 'calls into store to resolve linked types' do
-    allow(store).to receive(:find)
-      .with('blockText1234', anything)
-      .and_return(
-        {
-          'sys' => {
-            'type' => 'Entry',
-            'contentType' => {
-              'sys' => {
-                'id' => 'sectionBlockText'
-              }
-            }
-          },
-          'fields' => {
-            'text' => {
-              'en-US' => 'Lorem Ipsum Dolor Sit Amet'
-            }
-          }
-        }
-      )
-
-    # act
-    post = TestNamespace::BlogPost.new({
-      'sys' => {
-        'type' => 'Entry',
-        'contentType' => {
-          'sys' => {
-            'id' => 'blogPost'
-          }
-        }
-      },
-      'fields' => {
-        'sections' => {
-          'en-US' => [
-            {
-              'sys' => {
-                'type' => 'Link',
-                'linkType' => 'Entry',
-                'id' => 'blockText1234'
-              }
-            }
-          ]
-        }
-      }
-    })
-
-    # assert
-    expect(post.sections[0]).to be_a TestNamespace::SectionBlockText
-    expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
   end
 
   class TestNamespace

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
     TestNamespace.instance_variable_set('@configuration', nil)
 
     TestNamespace.configure(services: services) do |config|
-      config.schema_file = fixture_path('contentful/blog-contentful-schema.json')
+      config.schema_file = path_to_fixture('contentful/blog-contentful-schema.json')
     end
   end
 
@@ -313,7 +313,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
     }.to instrument('find.model.contentful.wcc')
   end
 
-  it 'subclass instruments find using configured instrumentation', focus: true do
+  it 'subclass instruments find using configured instrumentation' do
     class MyBlogPost2 < TestNamespace::BlogPost
     end
 

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -3,6 +3,14 @@
 require 'wcc/contentful/model_api'
 
 RSpec.describe WCC::Contentful::ModelAPI do
+  let(:store) {
+    double('store')
+  }
+
+  let(:services) {
+    double('services', store: store, instrumentation: ActiveSupport::Notifications)
+  }
+
   before do
     consts = TestNamespace.constants(false).map(&:to_s).uniq
     consts.each do |c|
@@ -14,8 +22,12 @@ RSpec.describe WCC::Contentful::ModelAPI do
     end
     TestNamespace.class_variable_get('@@registry').clear
     TestNamespace.instance_variable_set('@schema', nil)
+    TestNamespace.instance_variable_set('@services', nil)
+    TestNamespace.instance_variable_set('@configuration', nil)
 
-    TestNamespace.schema file: fixture_path('contentful/blog-contentful-schema.json')
+    TestNamespace.configure(services: services) do |config|
+      config.schema_file = fixture_path('contentful/blog-contentful-schema.json')
+    end
   end
 
   it 'builds classes under namespace' do
@@ -204,6 +216,101 @@ RSpec.describe WCC::Contentful::ModelAPI do
     # assert
     expect(post.sections[0]).to be_instance_of(MyBlockText)
     expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
+  end
+
+  it 'finds models by ID' do
+    allow(store).to receive(:find)
+      .with('1234', anything)
+      .and_return({
+        'sys' => {
+          'id' => '1234',
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'title' => {
+            'en-US' => 'Lorem Ipsum'
+          }
+        }
+      })
+
+    # act
+    entry = TestNamespace.find('1234')
+
+    # assert
+    expect(entry).to be_a(TestNamespace::BlogPost)
+    expect(entry.id).to eq('1234')
+    expect(entry.title).to eq('Lorem Ipsum')
+  end
+
+  it 'finds by ID on derived class' do
+    allow(store).to receive(:find)
+      .with('1234', anything)
+      .and_return({
+        'sys' => {
+          'id' => '1234',
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'title' => {
+            'en-US' => 'Lorem Ipsum'
+          }
+        }
+      })
+
+    # act
+    entry = TestNamespace::BlogPost.find('1234')
+
+    # assert
+    expect(entry).to be_a(TestNamespace::BlogPost)
+    expect(entry.id).to eq('1234')
+    expect(entry.title).to eq('Lorem Ipsum')
+  end
+
+  it 'finds by ID on subclass' do
+    allow(store).to receive(:find)
+      .with('1234', anything)
+      .and_return({
+        'sys' => {
+          'id' => '1234',
+          'type' => 'Entry',
+          'contentType' => {
+            'sys' => {
+              'id' => 'blogPost'
+            }
+          }
+        },
+        'fields' => {
+          'title' => {
+            'en-US' => 'Lorem Ipsum'
+          }
+        }
+      })
+
+    # act
+    entry = TestNamespace::BlogPost.find('1234')
+
+    # assert
+    expect(entry).to be_a(TestNamespace::BlogPost)
+    expect(entry.id).to eq('1234')
+    expect(entry.title).to eq('Lorem Ipsum')
+  end
+
+  it 'instruments find' do
+    allow(store).to receive(:find)
+    # act
+    expect {
+      TestNamespace::BlogPost.find('1234')
+    }.to instrument('find.model.contentful.wcc')
   end
 
   class TestNamespace

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
   end
 
   describe '.configure' do
-    it 'applies custom instrumentation adapter to the whole stack', focus: true do
+    it 'applies custom instrumentation adapter to the whole stack' do
       instrumentation = double('instrumentation')
 
       TestNamespace.configure do |config|

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -457,6 +457,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
       instrumentation = double('instrumentation')
 
       TestNamespace.configure do |config|
+        config.space = 'test'
         config.schema_file = path_to_fixture('contentful/blog-contentful-schema.json')
         config.instrumentation_adapter = instrumentation
       end

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'wcc/contentful/model_api'
+
+RSpec.describe WCC::Contentful::ModelAPI do
+  before do
+    consts = TestNamespace.constants(false).map(&:to_s).uniq
+    consts.each do |c|
+      begin
+        TestNamespace.send(:remove_const, c.split(':').last)
+      rescue StandardError => e
+        warn e
+      end
+    end
+    TestNamespace.class_variable_get('@@registry').clear
+    TestNamespace.instance_variable_set('@schema', nil)
+
+    TestNamespace.schema file: fixture_path('contentful/blog-contentful-schema.json')
+  end
+
+  it 'builds classes under namespace' do
+    expect(TestNamespace.constants(false).sort).to eq(
+      %i[
+        Asset
+        BlogPost
+        Category
+        Collection
+        MigrationHistory
+        PageMetadata
+        Property
+        PublishingTarget
+        SectionBlockText
+        SectionPullQuote
+        SectionScriptureQuote
+        SectionVideoEmbed
+        Tag
+      ]
+    )
+  end
+
+  it 'resolves json blobs' do
+    # act
+    migration = TestNamespace::MigrationHistory.new({
+      'sys' => {
+        'type' => 'Entry',
+        'contentType' => {
+          'sys' => {
+            'id' => 'migrationHistory'
+          }
+        }
+      },
+      'fields' => {
+        'detail' => {
+          'en-US' => [
+            {
+              'intent' => {
+                'intents' => [
+                  {
+                    'meta' => {
+                      'callsite' => {
+                        'file' =>
+                          './jtj-com/db/migrate/20180219160530_test_migration.ts',
+                        'line' => 3
+                      },
+                      'contentTypeInstanceId' => 'contentType/dog/0'
+                    },
+                    'type' => 'contentType/create',
+                    'payload' => {
+                      'contentTypeId' => 'dog'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    # assert
+    expect(migration.detail).to be_instance_of(Array)
+    expect(migration.detail[0]).to be_instance_of(OpenStruct)
+    expect(migration.detail.dig(0, 'intent', 'intents')).to include(
+      {
+        'meta' => {
+          'callsite' => {
+            'file' =>
+              './jtj-com/db/migrate/20180219160530_test_migration.ts',
+            'line' => 3
+          },
+          'contentTypeInstanceId' => 'contentType/dog/0'
+        },
+        'type' => 'contentType/create',
+        'payload' => {
+          'contentTypeId' => 'dog'
+        }
+      }
+    )
+  end
+
+  # Note: see code comment inside model_builder.rb for why we do not parse DateTime objects
+  it 'does not parse date times' do
+    # act
+    post = TestNamespace::BlogPost.new({
+      'sys' => {
+        'type' => 'Entry',
+        'contentType' => {
+          'sys' => {
+            'id' => 'blogPost'
+          }
+        }
+      },
+      'fields' => {
+        'publishAt' => {
+          'en-US' => '2021-01-01'
+        }
+      }
+    })
+
+    # assert
+    expect(post.publish_at).to be_a String
+    expect(post.publish_at).to eq('2021-01-01')
+  end
+
+  it 'resolves linked types' do
+    # act
+    post = TestNamespace::BlogPost.new({
+      'sys' => {
+        'type' => 'Entry',
+        'contentType' => {
+          'sys' => {
+            'id' => 'blogPost'
+          }
+        }
+      },
+      'fields' => {
+        'sections' => {
+          'en-US' => [
+            {
+              'sys' => {
+                'type' => 'Entry',
+                'contentType' => {
+                  'sys' => {
+                    'id' => 'sectionBlockText'
+                  }
+                }
+              },
+              'fields' => {
+                'text' => {
+                  'en-US' => 'Lorem Ipsum Dolor Sit Amet'
+                }
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    # assert
+    expect(post.sections[0]).to be_instance_of(TestNamespace::SectionBlockText)
+    expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
+  end
+
+  it 'inherited class resolves linked types' do
+    class MyBlogPost < TestNamespace::BlogPost
+    end
+
+    class MyBlockText < TestNamespace::SectionBlockText
+    end
+
+    # act
+    post = MyBlogPost.new({
+      'sys' => {
+        'type' => 'Entry',
+        'contentType' => {
+          'sys' => {
+            'id' => 'blogPost'
+          }
+        }
+      },
+      'fields' => {
+        'sections' => {
+          'en-US' => [
+            {
+              'sys' => {
+                'type' => 'Entry',
+                'contentType' => {
+                  'sys' => {
+                    'id' => 'sectionBlockText'
+                  }
+                }
+              },
+              'fields' => {
+                'text' => {
+                  'en-US' => 'Lorem Ipsum Dolor Sit Amet'
+                }
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    # assert
+    expect(post.sections[0]).to be_instance_of(MyBlockText)
+    expect(post.sections[0].text).to eq('Lorem Ipsum Dolor Sit Amet')
+  end
+
+  class TestNamespace
+    include WCC::Contentful::ModelAPI
+  end
+end

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe WCC::Contentful::ModelBuilder do
   subject {
     WCC::Contentful::ModelBuilder.new(types)
@@ -638,7 +640,7 @@ RSpec.describe WCC::Contentful::ModelBuilder do
             def initialize(raw, context)
             end
           end
-      end
+      end.at_most(2).times
 
       # act
       button = WCC::Contentful::Model.find('5NBhDw3i2kUqSwqYok4YQO')
@@ -650,6 +652,7 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     it 'does not use loaded class if it does not exist' do
       expect(Object).to receive(:const_missing).with('MenuButton')
         .and_raise(NameError, 'uninitialized constant MenuButton')
+        .at_most(3).times
 
       # act
       button = WCC::Contentful::Model.find('5NBhDw3i2kUqSwqYok4YQO')

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -11,13 +11,17 @@ RSpec.describe WCC::Contentful::ModelBuilder do
       .and_return(types)
     types
   }
-  let!(:store) {
+  let(:store) {
     load_store_from_sync
   }
 
+  let(:services) {
+    double('services', store: store, instrumentation: ActiveSupport::Notifications)
+  }
+
   before do
-    allow(WCC::Contentful::Services.instance).to receive(:store)
-      .and_return(store)
+    allow(WCC::Contentful::Model).to receive(:services)
+      .and_return(services)
   end
 
   it 'builds models from loaded types' do

--- a/wcc-contentful/spec/wcc/contentful/model_methods_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_methods_spec.rb
@@ -265,8 +265,7 @@ RSpec.describe WCC::Contentful::ModelMethods do
       })
 
       preview_store = double('preview_store')
-      allow(WCC::Contentful::Model).to receive(:store)
-        .with(true)
+      allow(services).to receive(:preview_store)
         .and_return(preview_store)
 
       expect(store).to_not receive(:find_by)

--- a/wcc-contentful/spec/wcc/contentful/model_methods_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_methods_spec.rb
@@ -112,13 +112,21 @@ RSpec.describe WCC::Contentful::ModelMethods do
     double('store')
   }
 
+  let(:services) {
+    double('services',
+      store: store,
+      instrumentation: ActiveSupport::Notifications)
+  }
+
   subject {
     WCC::Contentful::Model::ToJsonTest.new(raw)
   }
 
   before do
-    builder = WCC::Contentful::ModelBuilder.new({ 'toJsonTest' => typedef })
-    builder.build_models
+    WCC::Contentful::Model.configure(
+      schema: { 'toJsonTest' => typedef },
+      services: services
+    )
 
     allow(WCC::Contentful::Model).to receive(:store)
       .with(no_args)
@@ -130,7 +138,7 @@ RSpec.describe WCC::Contentful::ModelMethods do
       .with(false)
       .and_return(store)
     allow(WCC::Contentful::Services).to receive(:instance)
-      .and_return(double('services', instrumentation: ActiveSupport::Notifications))
+      .and_return(services)
   end
 
   describe '#resolve' do

--- a/wcc-contentful/spec/wcc/contentful/store/cdn_adapter_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/cdn_adapter_spec.rb
@@ -464,6 +464,7 @@ RSpec.describe WCC::Contentful::Store::CDNAdapter, :vcr do
     {
       'sys' => {
         'id' => id,
+        'type' => 'Entry',
         'contentType' => {
           'sys' => {
             'type' => 'Link',

--- a/wcc-contentful/spec/wcc/contentful/sync_engine_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/sync_engine_spec.rb
@@ -22,14 +22,13 @@ RSpec.describe 'WCC::Contentful::SyncEngine::Job', type: :job do
   }
 
   before do
-    allow(WCC::Contentful::Services.instance).to receive(:store)
-      .and_return(store)
-
-    allow(WCC::Contentful::Services.instance).to receive(:client)
-      .and_return(client)
-
-    allow(WCC::Contentful::Services.instance).to receive(:sync_engine)
-      .and_return(sync_engine)
+    allow(WCC::Contentful::Services).to receive(:instance)
+      .and_return(double(
+                    store: store,
+                    client: client,
+                    sync_engine: sync_engine,
+                    instrumentation: ActiveSupport::Notifications
+                  ))
 
     described_class.instance_variable_set('@sync_engine', nil)
   end

--- a/wcc-contentful/spec/wcc/contentful_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe WCC::Contentful, :vcr do
         WCC::Contentful.init!
 
         # assert
-        store = WCC::Contentful::Model.store
+        store = WCC::Contentful::Model.services.store
         stack = [store]
         while store = store.try(:store)
           stack << store


### PR DESCRIPTION
This PR enables an app to create a Model layer in a separate Namespace (i.e. not under `WCC::Contentful::Model`).  This allows us to create a second Stack of `Model` -> `Store` -> `Client` to access a completely separate space within the same ruby process.  

The intent is that all recursive link resolution code should pull from the same Store where the original model came from.  Calling `.find` or `.find_by` on a model class should pull it from the correct space based on the Namespace.

The use case is to enable us to implement Papyrus inside of Paper Signs with an independent Contentful connection to the Papyrus space.

fixes #250 

Example usage:

```rb
# lib/papyrus/model.rb
class Papyrus::Model
  include WCC::Contentful::ModelAPI

  configure do |config|
    config.schema_file = 'db/papyrus-contentful-schema.json'
  end

end

# config/initializers/papyrus.rb
Papyrus::Model.configure do |config|
    config.space = '1234'
    config.access_token = 'xxxx'
end
```