### PR TITLE
Support Operator "in"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ Style/BlockDelimiters:
   Exclude:
     # we like the `let(:foo) {}` syntax in specs
     - '*/spec/**/*.rb'
-    - '**/rspec_examples/*.rb'
+    - '**/rspec_examples/**/*.rb'
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
@@ -123,7 +123,7 @@ Style/MultilineBlockChain:
   Exclude:
     # allow "expect { ... }.to raise_error do |ex|; end"
     - '*/spec/**/*.rb'
-    - '**/rspec_examples/*.rb'
+    - '**/rspec_examples/**/*.rb'
 
 
   # These are all the cops that are disabled in the default configuration.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Style/BlockDelimiters:
   Exclude:
     # we like the `let(:foo) {}` syntax in specs
     - '*/spec/**/*.rb'
+    - '**/rspec_examples/*.rb'
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
@@ -117,6 +118,12 @@ Layout/MultilineMethodCallIndentation:
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Style/MultilineBlockChain:
+  Exclude:
+    # allow "expect { ... }.to raise_error do |ex|; end"
+    - '*/spec/**/*.rb'
+    - '**/rspec_examples/*.rb'
 
 
   # These are all the cops that are disabled in the default configuration.

--- a/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/cdn_adapter.rb
@@ -105,6 +105,11 @@ module WCC::Contentful::Store
 
       def apply_operator(operator, field, expected, context = nil)
         op = operator == :eq ? nil : operator
+        if expected.is_a?(Array)
+          expected = expected.join(',')
+          op = :in if op.nil?
+        end
+
         param = parameter(field, operator: op, context: context, locale: true)
 
         self.class.new(

--- a/wcc-contentful/lib/wcc/contentful/store/memory_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/memory_store.rb
@@ -38,7 +38,7 @@ module WCC::Contentful::Store
       end
     end
 
-    SUPPORTED_OPS = %i[eq in].freeze
+    SUPPORTED_OPS = %i[eq ne in].freeze
 
     def execute(query)
       (query.conditions.map(&:op) - SUPPORTED_OPS).each do |op|
@@ -79,6 +79,18 @@ module WCC::Contentful::Store
           val.include?(condition.expected)
         else
           val == condition.expected
+        end
+      end
+    end
+
+    def apply_ne(memo, condition)
+      memo.select do |entry|
+        val = entry.dig(*condition.path)
+
+        if val.is_a? Array
+          !val.include?(condition.expected)
+        else
+          val != condition.expected
         end
       end
     end

--- a/wcc-contentful/lib/wcc/contentful/store/memory_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/memory_store.rb
@@ -39,6 +39,11 @@ module WCC::Contentful::Store
     end
 
     def execute(query)
+      query.conditions.each do |condition|
+        # Our naiive implementation only supports equality operator
+        raise ArgumentError, "Operator :#{condition.op} not supported" unless condition.op == :eq
+      end
+
       relation = mutex.with_read_lock { @hash.values }
 
       # relation is an enumerable that we apply conditions to in the form of
@@ -57,9 +62,6 @@ module WCC::Contentful::Store
       # enforces the condition.
       query.conditions.reduce(relation) do |memo, condition|
         memo.select do |entry|
-          # Our naiive implementation only supports equality operator
-          raise ArgumentError, "Operator #{condition.op} not supported" unless condition.op == :eq
-
           # The condition's path tells us where to find the value in the JSON object
           val = entry.dig(*condition.path)
 

--- a/wcc-contentful/lib/wcc/contentful/store/query.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/query.rb
@@ -34,6 +34,17 @@ module WCC::Contentful::Store
       @extra = extra
     end
 
+    FALSE_VALUES = [
+      false, 0,
+      '0', :"0",
+      'f', :f,
+      'F', :F,
+      'false', :false, # rubocop:disable Lint/BooleanSymbol
+      'FALSE', :FALSE,
+      'off', :off,
+      'OFF', :OFF
+    ].to_set.freeze
+
     # Returns a new chained Query that has a new condition.  The new condition
     # represents the WHERE comparison being applied here.  The underlying store
     # implementation translates this condition statement into an appropriate
@@ -52,6 +63,14 @@ module WCC::Contentful::Store
     def apply_operator(operator, field, expected, context = nil)
       operator ||= expected.is_a?(Array) ? :in : :eq
       raise ArgumentError, "Operator #{operator} not supported" unless respond_to?(operator)
+      raise ArgumentError, 'value cannot be nil (try using exists: false)' if expected.nil?
+
+      case operator
+      when :in, :nin, :all
+        expected = Array(expected)
+      when :exists
+        expected = !FALSE_VALUES.include?(expected)
+      end
 
       field = field.to_s if field.is_a? Symbol
       path = field.is_a?(Array) ? field : field.split('.')

--- a/wcc-contentful/lib/wcc/contentful/store/query.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/query.rb
@@ -50,6 +50,7 @@ module WCC::Contentful::Store
     # @expected The expected value to compare the field's value against.
     # @context A context object optionally containing `context[:locale]`
     def apply_operator(operator, field, expected, context = nil)
+      operator ||= expected.is_a?(Array) ? :in : :eq
       raise ArgumentError, "Operator #{operator} not supported" unless respond_to?(operator)
 
       field = field.to_s if field.is_a? Symbol
@@ -151,7 +152,7 @@ module WCC::Contentful::Store
           elsif op?(k)
             { path: path, op: k.to_sym, expected: v }
           else
-            { path: path + [k], op: :eq, expected: v }
+            { path: path + [k], op: nil, expected: v }
           end
         end
       end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative './rspec_examples/basic_store'
+require_relative './rspec_examples/operators'
 require_relative './rspec_examples/nested_queries'
 require_relative './rspec_examples/include_param'
 
@@ -41,6 +42,7 @@ RSpec.shared_examples 'contentful store' do |feature_set|
   }.merge(feature_set&.symbolize_keys || {})
 
   include_examples 'basic store'
+  include_examples 'operators', feature_set[:operators]
   include_examples 'supports nested queries', feature_set[:nested_queries]
   include_examples 'supports include param', feature_set[:include_param]
 end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'operators' do |feature_set|
+  supported_operators =
+    if feature_set.nil?
+      WCC::Contentful::Store::Query::Interface::OPERATORS
+        .each_with_object({}) { |k, h| h[k] = 'pending' }
+    elsif feature_set.is_a?(Array)
+      WCC::Contentful::Store::Query::Interface::OPERATORS
+        .each_with_object({}) { |k, h| h[k] = feature_set.include?(k.to_sym) }
+    elsif feature_s.is_a?(Hash)
+      feature_set
+    else
+      raise ArgumentError, 'Please provide a hash or array of operators to test'
+    end
+
+  context ':in' do
+    before { skip(':in operator not supported') } if supported_operators[:in] == false
+    before { pending(':in operator to be implemented') } if supported_operators[:in].to_s == 'pending'
+
+    it 'with array on string field' do
+      ids = 1.upto(10).to_a
+      data =
+        ids.map do |i|
+          {
+            'sys' => {
+              'id' => "k#{i}",
+              'contentType' => { 'sys' => { 'id' => 'test' } }
+            },
+            'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+          }
+        end
+      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+      to_find = ids.shuffle.take(2)
+
+      # act
+      found = subject.find_all(content_type: 'test')
+        .apply('name' => { in: to_find.map { |i| "test#{i}" } })
+
+      expect(found.count).to eq(2)
+      expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+        to_find.map { |i| "k#{i}" }.sort
+      )
+    end
+
+    it 'with array on array field' do
+      ids = 1.upto(10).to_a
+      data =
+        ids.map do |i|
+          {
+            'sys' => {
+              'id' => "k#{i}",
+              'contentType' => { 'sys' => { 'id' => 'test' } }
+            },
+            'fields' => { 'name' => { 'en-US' => ["test#{i}", "test_2_#{i}"] } }
+          }
+        end
+      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+      to_find1, to_find2 = ids.shuffle
+
+      # act
+      found = subject.find_all(content_type: 'test')
+        .apply('name' => { in: ["test#{to_find1}", "test_2_#{to_find2}"] })
+
+      expect(found.count).to eq(2)
+      expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+        ["k#{to_find1}", "k#{to_find2}"].sort
+      )
+    end
+
+    it 'defaults to :in, not :eq, when given an array' do
+      ids = 1.upto(10).to_a
+      data =
+        ids.map do |i|
+          {
+            'sys' => {
+              'id' => "k#{i}",
+              'contentType' => { 'sys' => { 'id' => 'test' } }
+            },
+            'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+          }
+        end
+      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+      to_find = ids.shuffle.take(3)
+
+      # act
+      found = subject.find_all(content_type: 'test')
+        .apply('name' => to_find.map { |i| "test#{i}" })
+
+      expect(found.count).to eq(3)
+      expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+        to_find.map { |i| "k#{i}" }.sort
+      )
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+require_relative './operators/in'
+
+(WCC::Contentful::Store::Query::Interface::OPERATORS -
+  %i[in]).each do |op|
+    RSpec.shared_examples "supports :#{op} operator" do
+      it 'TODO'
+    end
+  end
+
 RSpec.shared_examples 'operators' do |feature_set|
   supported_operators =
     if feature_set.nil?
@@ -14,86 +23,25 @@ RSpec.shared_examples 'operators' do |feature_set|
       raise ArgumentError, 'Please provide a hash or array of operators to test'
     end
 
-  context ':in' do
-    before { skip(':in operator not supported') } if supported_operators[:in] == false
-    before { pending(':in operator to be implemented') } if supported_operators[:in].to_s == 'pending'
+  supported_operators.each do |op, value|
+    next if value
 
-    it 'with array on string field' do
-      ids = 1.upto(10).to_a
-      data =
-        ids.map do |i|
-          {
-            'sys' => {
-              'id' => "k#{i}",
-              'contentType' => { 'sys' => { 'id' => 'test' } }
-            },
-            'fields' => { 'name' => { 'en-US' => "test#{i}" } }
-          }
-        end
-      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
-
-      to_find = ids.shuffle.take(2)
-
-      # act
-      found = subject.find_all(content_type: 'test')
-        .apply('name' => { in: to_find.map { |i| "test#{i}" } })
-
-      expect(found.count).to eq(2)
-      expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
-        to_find.map { |i| "k#{i}" }.sort
-      )
+    it "does not support :#{op}" do
+      expect {
+        subject.find_all(content_type: 'test')
+          .apply('name' => { op => 'test' })
+          .to_a
+      }.to raise_error do |ex|
+        expect(ex.to_s).to match(/not supported/)
+      end
     end
+  end
 
-    it 'with array on array field' do
-      ids = 1.upto(10).to_a
-      data =
-        ids.map do |i|
-          {
-            'sys' => {
-              'id' => "k#{i}",
-              'contentType' => { 'sys' => { 'id' => 'test' } }
-            },
-            'fields' => { 'name' => { 'en-US' => ["test#{i}", "test_2_#{i}"] } }
-          }
-        end
-      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+  supported_operators.each do |op, value|
+    next unless value
 
-      to_find1, to_find2 = ids.shuffle
-
-      # act
-      found = subject.find_all(content_type: 'test')
-        .apply('name' => { in: ["test#{to_find1}", "test_2_#{to_find2}"] })
-
-      expect(found.count).to eq(2)
-      expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
-        ["k#{to_find1}", "k#{to_find2}"].sort
-      )
-    end
-
-    it 'defaults to :in, not :eq, when given an array' do
-      ids = 1.upto(10).to_a
-      data =
-        ids.map do |i|
-          {
-            'sys' => {
-              'id' => "k#{i}",
-              'contentType' => { 'sys' => { 'id' => 'test' } }
-            },
-            'fields' => { 'name' => { 'en-US' => "test#{i}" } }
-          }
-        end
-      data.each { |d| subject.set(d.dig('sys', 'id'), d) }
-
-      to_find = ids.shuffle.take(3)
-
-      # act
-      found = subject.find_all(content_type: 'test')
-        .apply('name' => to_find.map { |i| "test#{i}" })
-
-      expect(found.count).to eq(3)
-      expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
-        to_find.map { |i| "k#{i}" }.sort
-      )
+    it_behaves_like "supports :#{op} operator" do
+      before { pending(":#{op} operator to be implemented") } if value == 'pending'
     end
   end
 end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require_relative './operators/eq'
+require_relative './operators/ne'
 require_relative './operators/in'
+require_relative './operators/nin'
 
 (WCC::Contentful::Store::Query::Interface::OPERATORS -
-  %i[eq in]).each do |op|
+  %i[eq ne in nin]).each do |op|
     RSpec.shared_examples "supports :#{op} operator" do
       it 'TODO'
     end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+require_relative './operators/eq'
 require_relative './operators/in'
 
 (WCC::Contentful::Store::Query::Interface::OPERATORS -
-  %i[in]).each do |op|
+  %i[eq in]).each do |op|
     RSpec.shared_examples "supports :#{op} operator" do
       it 'TODO'
     end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/eq.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/eq.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'supports :eq operator' do
+  [
+    [String, proc { "test#{rand(1..10_000)}" }],
+    [Integer, proc { rand(-4_611_686_018_427_387_903..4_611_686_018_427_387_903) }],
+    [Float, proc { rand }]
+  ].each do |(type, generator)|
+    context "with #{type} value" do
+      it 'find_by can apply filter object' do
+        data =
+          1.upto(3).map do |i|
+            {
+              'sys' => { 'id' => "k#{i}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+              'fields' => { type.to_s => { 'en-US' => generator.call } }
+            }
+          end
+
+        desired_value = generator.call
+        desired = {
+          'sys' => { 'id' => "k#{rand}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+          'fields' => { type.to_s => { 'en-US' => desired_value } }
+        }
+
+        data << desired
+        data.shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        found = subject.find_by(content_type: 'test1', filter: { type.to_s => desired_value })
+
+        # assert
+        expect(found).to_not be_nil
+        expect(found).to eq(desired)
+      end
+
+      it 'find_by can find value in array' do
+        data =
+          1.upto(3).map do |i|
+            {
+              'sys' => {
+                'id' => "k#{i}",
+                'contentType' => { 'sys' => { 'id' => 'test1' } }
+              },
+              'fields' => { 'name' => { 'en-US' => [generator.call, generator.call] } }
+            }
+          end
+
+        desired_value = generator.call
+        desired = {
+          'sys' => { 'id' => "k#{rand}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+          'fields' => { type.to_s => { 'en-US' => [generator.call, desired_value].shuffle } }
+        }
+
+        data << desired
+        data.shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        found = subject.find_by(content_type: 'test1', filter: { type.to_s => { eq: desired_value } })
+
+        # assert
+        expect(found).to_not be_nil
+        expect(found).to eq(desired)
+      end
+
+      it 'find_all can apply operator' do
+        data =
+          1.upto(3).map do |i|
+            {
+              'sys' => { 'id' => "k#{i}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+              'fields' => { type.to_s => { 'en-US' => generator.call } }
+            }
+          end
+
+        desired_value = generator.call
+        desired =
+          4.upto(5).map do |i|
+            {
+              'sys' => { 'id' => "k#{i}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+              'fields' => { type.to_s => { 'en-US' => desired_value } }
+            }
+          end
+
+        data += desired
+        data.shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        found = subject.find_all(content_type: 'test1')
+          .eq(type.to_s, desired_value)
+
+        # assert
+        expect(found.count).to eq(2)
+        sorted = found.to_a.sort_by { |item| item.dig('sys', 'id') }
+        expect(sorted).to eq(desired)
+      end
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/eq.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/eq.rb
@@ -7,23 +7,28 @@ RSpec.shared_examples 'supports :eq operator' do
     [Float, proc { rand }]
   ].each do |(type, generator)|
     context "with #{type} value" do
-      it 'find_by can apply filter object' do
-        data =
-          1.upto(3).map do |i|
-            {
-              'sys' => { 'id' => "k#{i}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
-              'fields' => { type.to_s => { 'en-US' => generator.call } }
-            }
-          end
+      let(:desired_value) {
+        generator.call
+      }
 
-        desired_value = generator.call
-        desired = {
+      let(:data) {
+        1.upto(3).map do |i|
+          {
+            'sys' => { 'id' => "k#{i}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+            'fields' => { type.to_s => { 'en-US' => generator.call } }
+          }
+        end
+      }
+
+      let(:desired) {
+        {
           'sys' => { 'id' => "k#{rand}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
           'fields' => { type.to_s => { 'en-US' => desired_value } }
         }
+      }
 
-        data << desired
-        data.shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+      it 'find_by can apply filter object' do
+        [*data, desired].shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
 
         # act
         found = subject.find_by(content_type: 'test1', filter: { type.to_s => desired_value })
@@ -63,15 +68,6 @@ RSpec.shared_examples 'supports :eq operator' do
       end
 
       it 'find_all can apply operator' do
-        data =
-          1.upto(3).map do |i|
-            {
-              'sys' => { 'id' => "k#{i}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
-              'fields' => { type.to_s => { 'en-US' => generator.call } }
-            }
-          end
-
-        desired_value = generator.call
         desired =
           4.upto(5).map do |i|
             {
@@ -80,8 +76,7 @@ RSpec.shared_examples 'supports :eq operator' do
             }
           end
 
-        data += desired
-        data.shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+        [*data, *desired].shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
 
         # act
         found = subject.find_all(content_type: 'test1')

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/in.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/in.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'supports :in operator' do
+  it 'with array on string field' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_find = ids.shuffle.take(2)
+
+    # act
+    found = subject.find_all(content_type: 'test')
+      .apply('name' => { in: to_find.map { |i| "test#{i}" } })
+
+    expect(found.count).to eq(2)
+    expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+      to_find.map { |i| "k#{i}" }.sort
+    )
+  end
+
+  it 'with array on array field' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => ["test#{i}", "test_2_#{i}"] } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_find1, to_find2 = ids.shuffle
+
+    # act
+    found = subject.find_all(content_type: 'test')
+      .apply('name' => { in: ["test#{to_find1}", "test_2_#{to_find2}"] })
+
+    expect(found.count).to eq(2)
+    expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+      ["k#{to_find1}", "k#{to_find2}"].sort
+    )
+  end
+
+  it 'defaults to :in, not :eq, when given an array' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_find = ids.shuffle.take(3)
+
+    # act
+    found = subject.find_all(content_type: 'test')
+      .apply('name' => to_find.map { |i| "test#{i}" })
+
+    expect(found.count).to eq(3)
+    expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+      to_find.map { |i| "k#{i}" }.sort
+    )
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/in.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/in.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'supports :in operator' do
-  it 'with array on string field' do
+  it 'find_all with array on string field' do
     ids = 1.upto(10).to_a
     data =
       ids.map do |i|
@@ -19,15 +19,15 @@ RSpec.shared_examples 'supports :in operator' do
 
     # act
     found = subject.find_all(content_type: 'test')
-      .apply('name' => { in: to_find.map { |i| "test#{i}" } })
+      .in('name', to_find.map { |i| "test#{i}" })
 
     expect(found.count).to eq(2)
-    expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+    expect(found.map { |item| item.dig('sys', 'id') }.sort).to eq(
       to_find.map { |i| "k#{i}" }.sort
     )
   end
 
-  it 'with array on array field' do
+  it 'find_all with array on array field' do
     ids = 1.upto(10).to_a
     data =
       ids.map do |i|
@@ -45,15 +45,15 @@ RSpec.shared_examples 'supports :in operator' do
 
     # act
     found = subject.find_all(content_type: 'test')
-      .apply('name' => { in: ["test#{to_find1}", "test_2_#{to_find2}"] })
+      .in('name', ["test#{to_find1}", "test_2_#{to_find2}"])
 
     expect(found.count).to eq(2)
-    expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+    expect(found.map { |item| item.dig('sys', 'id') }.sort).to eq(
       ["k#{to_find1}", "k#{to_find2}"].sort
     )
   end
 
-  it 'defaults to :in, not :eq, when given an array' do
+  it 'find_all defaults to :in when given an array' do
     ids = 1.upto(10).to_a
     data =
       ids.map do |i|
@@ -74,8 +74,58 @@ RSpec.shared_examples 'supports :in operator' do
       .apply('name' => to_find.map { |i| "test#{i}" })
 
     expect(found.count).to eq(3)
-    expect(found.map { |item| item.dig('sys', 'id') }).sort.to eq(
+    expect(found.map { |item| item.dig('sys', 'id') }.sort).to eq(
       to_find.map { |i| "k#{i}" }.sort
     )
+  end
+
+  it 'find_by with array on string field' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_find = ids.sample
+
+    # act
+    found = subject.find_by(
+      content_type: 'test',
+      filter: { name: { in: ['asdf', "test#{to_find}"] } }
+    )
+
+    expect(found.dig('sys', 'id')).to eq("k#{to_find}")
+  end
+
+  it 'find_by defaults to :in when given an array' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_find = ids.sample
+
+    # act
+    found = subject.find_by(
+      content_type: 'test',
+      filter: { name: ['asdf', "test#{to_find}"] }
+    )
+
+    expect(found.dig('sys', 'id')).to eq("k#{to_find}")
   end
 end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/ne.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/ne.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'supports :ne operator' do
+  [
+    [String, proc { "test#{rand(1..100_000)}" }],
+    [Integer, proc { rand(-4_611_686_018_427_387_903..4_611_686_018_427_387_903) }],
+    [Float, proc { rand }]
+  ].each do |(type, generator)|
+    context "with #{type} value" do
+      let(:specified_value) {
+        generator.call
+      }
+
+      let(:desired) {
+        # desired entry doesn't have the specified_value
+        {
+          'sys' => { 'id' => "k#{rand}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+          'fields' => { type.to_s => { 'en-US' => 1.upto(rand(2..5)).map { generator.call } } }
+        }
+      }
+
+      let(:data) {
+        1.upto(3).map do |i|
+          random_values = 1.upto(rand(2..5)).map { generator.call }
+
+          # remaining data does include the specified_value
+          {
+            'sys' => {
+              'id' => "k#{i}",
+              'contentType' => { 'sys' => { 'id' => 'test1' } }
+            },
+            'fields' => { 'name' => { 'en-US' => [*random_values, specified_value].shuffle } }
+          }
+        end
+      }
+
+      it 'find_by can apply filter object' do
+        specified_value = generator.call
+        data = {
+          'sys' => { 'id' => "k#{rand}", 'contentType' => { 'sys' => { 'id' => 'test1' } } },
+          'fields' => { type.to_s => { 'en-US' => specified_value } }
+        }
+
+        subject.set(data.dig('sys', 'id'), data)
+
+        # act
+        found = subject.find_by(content_type: 'test1', filter: { type.to_s => { ne: specified_value } })
+
+        # assert
+        expect(found).to be_nil
+      end
+
+      it 'find_by can find value in array' do
+        [*data, desired].shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        found = subject.find_by(content_type: 'test1', filter: { type.to_s => { eq: specified_value } })
+
+        # assert
+        expect(found).to_not be_nil
+        expect(found).to eq(desired)
+      end
+
+      it 'find_all can apply operator' do
+        [*data, desired].shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+        # act
+        found = subject.find_all(content_type: 'test1')
+          .ne(type.to_s, specified_value)
+
+        # assert
+        expect(found.count).to eq(1)
+        expect(found.first).to eq(desired)
+      end
+    end
+  end
+end

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/ne.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/ne.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples 'supports :ne operator' do
               'id' => "k#{i}",
               'contentType' => { 'sys' => { 'id' => 'test1' } }
             },
-            'fields' => { 'name' => { 'en-US' => [*random_values, specified_value].shuffle } }
+            'fields' => { type.to_s => { 'en-US' => [*random_values, specified_value].shuffle } }
           }
         end
       }
@@ -54,7 +54,7 @@ RSpec.shared_examples 'supports :ne operator' do
         [*data, desired].shuffle.each { |d| subject.set(d.dig('sys', 'id'), d) }
 
         # act
-        found = subject.find_by(content_type: 'test1', filter: { type.to_s => { eq: specified_value } })
+        found = subject.find_by(content_type: 'test1', filter: { type.to_s => { ne: specified_value } })
 
         # assert
         expect(found).to_not be_nil

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/nin.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/operators/nin.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'supports :nin operator' do
+  it 'find_all with array on string field' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_exclude = ids.shuffle.take(2)
+
+    # act
+    found = subject.find_all(content_type: 'test')
+      .nin('name', to_exclude.map { |i| "test#{i}" })
+
+    expect(found.count).to eq(8)
+    expect(found.map { |item| item.dig('sys', 'id') }.sort).to eq(
+      (ids - to_exclude).map { |i| "k#{i}" }.sort
+    )
+  end
+
+  it 'find_all with array on array field' do
+    ids = 1.upto(10).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => ["test#{i}", "test_2_#{i}"] } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_exclude1, to_exclude2 = ids.shuffle
+
+    # act
+    found = subject.find_all(content_type: 'test')
+      .nin('name', ["test#{to_exclude1}", "test_2_#{to_exclude2}"])
+
+    expect(found.count).to eq(8)
+    expect(found.map { |item| item.dig('sys', 'id') }.sort).to eq(
+      (ids - [to_exclude1, to_exclude2]).map { |i| "k#{i}" }.sort
+    )
+  end
+
+  it 'find_by with array on string field' do
+    ids = 1.upto(2).to_a
+    data =
+      ids.map do |i|
+        {
+          'sys' => {
+            'id' => "k#{i}",
+            'contentType' => { 'sys' => { 'id' => 'test' } }
+          },
+          'fields' => { 'name' => { 'en-US' => "test#{i}" } }
+        }
+      end
+    data.each { |d| subject.set(d.dig('sys', 'id'), d) }
+
+    to_exclude, to_expect = ids.shuffle
+
+    # act
+    found = subject.find_by(
+      content_type: 'test',
+      filter: { name: { nin: ['asdf', "test#{to_exclude}"] } }
+    )
+
+    expect(found.dig('sys', 'id')).to eq("k#{to_expect}")
+  end
+end

--- a/wcc-contentful/spec/wcc/contentful/store/cdn_adapter_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/cdn_adapter_spec.rb
@@ -342,6 +342,45 @@ RSpec.describe WCC::Contentful::Store::CDNAdapter, :vcr do
       expect(page.dig('fields', 'title', 'en-US')).to eq('Conferences')
     end
 
+    it 'defaults to :in if given an array' do
+      stub = stub_request(:get,
+        'https://cdn.contentful.com/spaces/hw5pse7y1ojx/entries?content_type=conference&fields.tags.en-US%5Bin%5D=a,b&locale=*')
+        .to_return(body: {
+          sys: { type: 'Array' },
+          total: 2,
+          items: [
+            { sys: { type: 'Entry', id: '1' } },
+            { sys: { type: 'Entry', id: '2' } }
+          ]
+        }.to_json)
+
+      # act
+      found = adapter.find_all(content_type: 'conference')
+        .apply(tags: %w[a b])
+
+      expect(found.count).to eq(2)
+      expect(stub).to have_been_requested
+    end
+
+    it 'handles nin with array' do
+      stub = stub_request(:get,
+        'https://cdn.contentful.com/spaces/hw5pse7y1ojx/entries?content_type=conference&fields.tags.en-US%5Bnin%5D=a,b&locale=*')
+        .to_return(body: {
+          sys: { type: 'Array' },
+          total: 1,
+          items: [
+            { sys: { type: 'Entry', id: '1' } }
+          ]
+        }.to_json)
+
+      # act
+      found = adapter.find_all(content_type: 'conference')
+        .apply(tags: { nin: %w[a b] })
+
+      expect(found.count).to eq(1)
+      expect(stub).to have_been_requested
+    end
+
     it 'recursively resolves links if include > 0' do
       stub_request(:get, "https://cdn.contentful.com/spaces/#{contentful_space_id}/entries" \
         '?content_type=page&include=2&limit=5&locale=*')

--- a/wcc-contentful/spec/wcc/contentful/store/cdn_adapter_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/cdn_adapter_spec.rb
@@ -344,7 +344,8 @@ RSpec.describe WCC::Contentful::Store::CDNAdapter, :vcr do
 
     it 'defaults to :in if given an array' do
       stub = stub_request(:get,
-        'https://cdn.contentful.com/spaces/hw5pse7y1ojx/entries?content_type=conference&fields.tags.en-US%5Bin%5D=a,b&locale=*')
+        "https://cdn.contentful.com/spaces/#{contentful_space_id}/entries"\
+          '?content_type=conference&fields.tags.en-US%5Bin%5D=a,b&locale=*')
         .to_return(body: {
           sys: { type: 'Array' },
           total: 2,
@@ -364,7 +365,8 @@ RSpec.describe WCC::Contentful::Store::CDNAdapter, :vcr do
 
     it 'handles nin with array' do
       stub = stub_request(:get,
-        'https://cdn.contentful.com/spaces/hw5pse7y1ojx/entries?content_type=conference&fields.tags.en-US%5Bnin%5D=a,b&locale=*')
+        "https://cdn.contentful.com/spaces/#{contentful_space_id}/entries"\
+          '?content_type=conference&fields.tags.en-US%5Bnin%5D=a,b&locale=*')
         .to_return(body: {
           sys: { type: 'Array' },
           total: 1,

--- a/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WCC::Contentful::Store::MemoryStore do
   it_behaves_like 'contentful store', {
     nested_queries: false,
     include_param: 0,
-    operators: %i[eq in]
+    operators: %i[eq ne in]
   }
 
   it 'returns all keys' do

--- a/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WCC::Contentful::Store::MemoryStore do
   it_behaves_like 'contentful store', {
     nested_queries: false,
     include_param: 0,
-    operators: %i[eq ne in]
+    operators: %i[eq ne in nin]
   }
 
   it 'returns all keys' do

--- a/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe WCC::Contentful::Store::MemoryStore do
 
   it_behaves_like 'contentful store', {
     nested_queries: false,
-    include_param: 0
+    include_param: 0,
+    operators: [:eq]
   }
 
   it 'returns all keys' do

--- a/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/memory_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WCC::Contentful::Store::MemoryStore do
   it_behaves_like 'contentful store', {
     nested_queries: false,
     include_param: 0,
-    operators: [:eq]
+    operators: %i[eq in]
   }
 
   it 'returns all keys' do

--- a/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/postgres_store_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe WCC::Contentful::Store::PostgresStore do
 
   it_behaves_like 'contentful store', {
     nested_queries: true,
-    include_param: true
+    include_param: true,
+    operators: [:eq]
   }
 
   let(:entry) do

--- a/wcc-contentful/spec/wcc/contentful/store/query_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/store/query_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe WCC::Contentful::Store::Query do
   end
 
   describe '#apply' do
-    it 'adds a single condition' do
+    it 'adds a single condition (assumes :eq)' do
       query = subject.apply({ f: 'test' })
 
       cond = query.conditions[0]
@@ -173,6 +173,16 @@ RSpec.describe WCC::Contentful::Store::Query do
       expect(cond2.expected).to eq('/test')
 
       expect(query.conditions.length).to eq(3)
+    end
+
+    it 'assumes :in when value is array and op not provided' do
+      query = subject.apply({ f: %w[test test2] })
+
+      cond = query.conditions[0]
+      expect(cond&.path).to eq(['fields', 'f', 'en-US'])
+      expect(cond.op).to eq(:in)
+      expect(cond.expected).to eq(%w[test test2])
+      expect(query.conditions.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Support the `:in`  operators on CDN Adapter

This is required for https://github.com/watermarkchurch/paper-signs/issues/2702 and https://github.com/watermarkchurch/paper-signs/issues/2703
In order to resolve Properties that link to the blog post's Categories, I want to execute this query within a blog post:

```ruby
Papyrus::Property.find_all(
  categories: { id: categories_ids }
)
```
which should result in a query similar to this:
```
https://cdn.contentful.com/spaces/xxxxxx/entries?content_type=property&fields.categories.sys.id%5Bin%5D=3snRTIDPQFaAUiLda3QdTc,63V41sK2c5lXhKv3y7bZnH&include=0
```

I have confirmed that the above query results in the correct data via the Contentful CDN