### PR TITLE
Explicit Webhook route

### DIFF
--- a/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
+++ b/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
@@ -13,18 +13,17 @@ module WCC::Contentful
       client = WCC::Contentful::SimpleClient::Management.new(
         args
       )
-      enable_webhook(client, args.slice(:app_url, :webhook_username, :webhook_password))
+      enable_webhook(client, args.slice(:receive_url, :webhook_username, :webhook_password))
     end
 
-    def enable_webhook(client, app_url:, webhook_username: nil, webhook_password: nil)
-      expected_url = URI.join(app_url, 'webhook/receive').to_s
-      webhook = client.webhook_definitions.items.find { |w| w['url'] == expected_url }
+    def enable_webhook(client, receive_url:, webhook_username: nil, webhook_password: nil)
+      webhook = client.webhook_definitions.items.find { |w| w['url'] == receive_url }
       logger.debug "existing webhook: #{webhook.inspect}" if webhook
       return if webhook
 
       body = {
         'name' => 'WCC::Contentful webhook',
-        'url' => expected_url,
+        'url' => receive_url,
         'topics' => [
           '*.publish',
           '*.unpublish'
@@ -50,13 +49,14 @@ module WCC::Contentful
 
       {
         management_token: config.management_token,
-        app_url: config.app_url,
         space: config.space,
         environment: config.environment,
         default_locale: config.default_locale,
         connection: config.connection,
         webhook_username: config.webhook_username,
-        webhook_password: config.webhook_password
+        webhook_password: config.webhook_password,
+
+        receive_url: URI.join(config.app_url, 'webhook/receive').to_s
       }
     end
 

--- a/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
+++ b/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
 
       # act
       job.enable_webhook(client,
-        app_url: 'https://test.url')
+        receive_url: 'https://test.url/webhook/receive')
 
       # assert
       # client should not receive a "post" message.
@@ -37,7 +37,7 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
 
       # act
       job.enable_webhook(client,
-        app_url: 'https://test.url/')
+        receive_url: 'https://test.url/webhook/receive')
     end
 
     it 'posts webhook with auth if auth given' do
@@ -54,7 +54,7 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
 
       # act
       job.enable_webhook(client,
-        app_url: 'https://test.url/',
+        receive_url: 'https://test.url/webhook/receive',
         webhook_username: 'testuser',
         webhook_password: 'testpw')
     end
@@ -82,7 +82,7 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
 
       # act
       job.enable_webhook(client,
-        app_url: 'https://test.url/')
+        receive_url: 'https://test.url/webhook/receive')
     end
   end
 
@@ -102,7 +102,7 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
     it 'gets default client params from WCC::Contentful.configuration' do
       defaults = {
         management_token: 'testtoken',
-        app_url: 'testurl',
+        app_url: 'http://testurl',
         space: 'testspace',
         environment: 'testenv',
         default_locale: 'testlocale',
@@ -118,8 +118,6 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
         expect(client).to be_a WCC::Contentful::SimpleClient::Management
 
         options = client.instance_variable_get('@options')
-        expect(options.except(:connection))
-          .to eq(defaults.except(:space, :management_token, :connection))
         expect(client.space).to eq('testspace')
         expect(client.instance_variable_get('@access_token')).to eq('testtoken')
         expect(options[:connection]).to eq(:typhoeus)


### PR DESCRIPTION
Allow specifying an explicit webhook route

Needed for https://github.com/watermarkchurch/paper-signs/pull/2729
Usage:
```rb
      WCC::Contentful::WebhookEnableJob.set(wait: 10.seconds).perform_later({
        management_token: config.management_token,
        space: config.space,
        environment: config.environment,
        default_locale: config.default_locale,
        connection: config.connection,
        webhook_username: config.webhook_username,
        webhook_password: config.webhook_password,

        # The webhook is mounted under the "papyrus" namespace
        receive_url: URI.join(config.app_url, 'papyrus/webhook/receive').to_s,
      })
```