### PR TITLE
Registry fix

### DIFF
--- a/wcc-contentful-app/spec/rails_helper.rb
+++ b/wcc-contentful-app/spec/rails_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.before(:each) do
-    WCC::Contentful::Model.class_variable_get('@@registry').clear
+    WCC::Contentful::Model.instance_variable_get('@registry').clear
     Wisper.clear
     WCC::Contentful.instance_variable_set('@configuration', nil)
     WCC::Contentful.instance_variable_set('@initialized', nil)

--- a/wcc-contentful-app/spec/requests/wcc/contentful/app/contact_form_controller_spec.rb
+++ b/wcc-contentful-app/spec/requests/wcc/contentful/app/contact_form_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe WCC::Contentful::App::ContactFormController, type: :request do
     end
 
     after do
-      WCC::Contentful::Model.class_variable_get('@@registry').clear
+      WCC::Contentful::Model.instance_variable_get('@registry').clear
     end
 
     it 'resolves to the descendant contact form override' do

--- a/wcc-contentful-app/spec/wcc/contentful/model/section_contact_form_spec.rb
+++ b/wcc-contentful-app/spec/wcc/contentful/model/section_contact_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WCC::Contentful::Model::SectionContactForm do
 
     after do
       # clean out MyContactForm subclass
-      WCC::Contentful::Model.class_variable_get('@@registry').clear
+      WCC::Contentful::Model.instance_variable_get('@registry').clear
     end
 
     Person = Struct.new(:id, :first_name, :last_name, :email)

--- a/wcc-contentful-graphql/spec/spec_helper.rb
+++ b/wcc-contentful-graphql/spec/spec_helper.rb
@@ -57,7 +57,7 @@ RSpec.configure do |config|
         warn e
       end
     end
-    WCC::Contentful::Model.class_variable_get('@@registry').clear
+    WCC::Contentful::Model.instance_variable_get('@registry').clear
   end
 end
 

--- a/wcc-contentful-middleman/spec/spec_helper.rb
+++ b/wcc-contentful-middleman/spec/spec_helper.rb
@@ -45,7 +45,7 @@ RSpec.shared_context 'Contentful config' do
         warn e
       end
     end
-    WCC::Contentful::Model.class_variable_get('@@registry').clear
+    WCC::Contentful::Model.instance_variable_get('@registry').clear
     Wisper.clear
   end
 end
@@ -80,7 +80,7 @@ RSpec.configure do |config|
         warn e
       end
     end
-    WCC::Contentful::Model.class_variable_get('@@registry').clear
+    WCC::Contentful::Model.instance_variable_get('@registry').clear
 
     # set up initialization mocks
     stub_request(:get, /https:\/\/cdn.contentful.com\/spaces\/.+\/sync/)

--- a/wcc-contentful/lib/wcc/contentful/model.rb
+++ b/wcc-contentful/lib/wcc/contentful/model.rb
@@ -41,10 +41,6 @@ require_relative './model_api'
 class WCC::Contentful::Model
   include WCC::Contentful::ModelAPI
 
-  # The Model base class maintains a registry which is best expressed as a
-  # class var.
-  # rubocop:disable Style/ClassVars
-
   class << self
     def const_missing(name)
       type = WCC::Contentful::Helpers.content_type_from_constant(name)
@@ -53,5 +49,3 @@ class WCC::Contentful::Model
     end
   end
 end
-
-# rubocop:enable Style/ClassVars

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -178,10 +178,12 @@ module WCC::Contentful::ModelAPI
       _registry[content_type]
     end
 
-    private
+    protected
 
     def _registry
-      @registry
+      # If calling register_for_content_type in a subclass, look up the superclass
+      # chain until we get to the model namespace which defines the registry
+      @registry || superclass._registry
     end
   end
 end

--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -13,9 +13,8 @@ module WCC::Contentful::ModelAPI
       services.instrumentation
     end
 
-    # We use a class var here because this is a global registry for all subclasses
-    # of this namespace
-    @@registry = {} # rubocop:disable Style/ClassVars
+    # Set the registry at the top of the namespace
+    @registry = {}
   end
 
   class_methods do
@@ -89,7 +88,7 @@ module WCC::Contentful::ModelAPI
     def resolve_constant(content_type)
       raise ArgumentError, 'content_type cannot be nil' unless content_type
 
-      const = @@registry[content_type]
+      const = _registry[content_type]
       return const if const
 
       const_name = WCC::Contentful::Helpers.constant_from_content_type(content_type).to_s
@@ -143,14 +142,14 @@ module WCC::Contentful::ModelAPI
 
       content_type ||= WCC::Contentful::Helpers.content_type_from_constant(klass)
 
-      @@registry[content_type] = klass
+      _registry[content_type] = klass
     end
 
     # Returns the current registry of content type names to constants.
     def registry
-      return {} unless @@registry
+      return {} unless _registry
 
-      @@registry.dup.freeze
+      _registry.dup.freeze
     end
 
     def reload!
@@ -176,7 +175,13 @@ module WCC::Contentful::ModelAPI
     # that class.  If nil, the generated WCC::Contentful::Model::{content_type} class
     # will be resolved for this content type.
     def registered?(content_type)
-      @@registry[content_type]
+      _registry[content_type]
+    end
+
+    private
+
+    def _registry
+      @registry
     end
   end
 end

--- a/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_singleton_methods.rb
@@ -69,9 +69,9 @@ module WCC::Contentful::ModelSingletonMethods
   def inherited(subclass)
     # If another different class is already registered for this content type,
     # don't auto-register this one.
-    return if WCC::Contentful::Model.registered?(content_type)
+    return if model_namespace.registered?(content_type)
 
-    WCC::Contentful::Model.register_for_content_type(content_type, klass: subclass)
+    model_namespace.register_for_content_type(content_type, klass: subclass)
   end
 
   class ModelQuery

--- a/wcc-contentful/spec/spec_helper.rb
+++ b/wcc-contentful/spec/spec_helper.rb
@@ -41,7 +41,7 @@ RSpec.shared_context 'Contentful config' do
         warn e
       end
     end
-    WCC::Contentful::Model.class_variable_get('@@registry').clear
+    WCC::Contentful::Model.instance_variable_get('@registry').clear
 
     WCC::Contentful::Model.instance_variable_set('@schema', nil)
     WCC::Contentful::Model.instance_variable_set('@services', nil)

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -684,7 +684,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
       expect(button).to be_a(blog_post_class)
     end
 
-    it 'two different namespaces have two different registries', focus: true do
+    it 'two different namespaces have two different registries' do
       alternate_schema = WCC::Contentful::IndexedRepresentation.from_json <<~JSON
         {
           "Asset": {
@@ -854,7 +854,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
         warn e
       end
     end
-    TestNamespace::Model.class_variable_get('@@registry').clear
+    TestNamespace::Model.instance_variable_get('@registry').clear
     TestNamespace::Model.instance_variable_set('@schema', nil)
     TestNamespace::Model.instance_variable_set('@services', nil)
     TestNamespace::Model.instance_variable_set('@configuration', nil)

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -683,6 +683,129 @@ RSpec.describe WCC::Contentful::ModelAPI do
       # assert
       expect(button).to be_a(blog_post_class)
     end
+
+    it 'two different namespaces have two different registries', focus: true do
+      alternate_schema = WCC::Contentful::IndexedRepresentation.from_json <<~JSON
+        {
+          "Asset": {
+            "fields": {
+              "title": {
+                "name": "title",
+                "type": "String"
+              },
+              "description": {
+                "name": "description",
+                "type": "String"
+              },
+              "file": {
+                "name": "file",
+                "type": "Json"
+              }
+            },
+            "name": "Asset",
+            "content_type": "Asset"
+          },
+          "blogPost": {
+            "fields": {
+              "metadata": {
+                "name": "metadata",
+                "type": "Link",
+                "required": false,
+                "link_types": [
+                  "pageMetadata"
+                ]
+              }
+            },
+            "name": "BlogPost",
+            "content_type": "blogPost"
+          },
+          "pageMetadata": {
+            "fields": {
+              "alt": {
+                "name": "alt",
+                "type": "String",
+                "required": true
+              }
+            },
+            "name": "PageMetadata",
+            "content_type": "pageMetadata"
+          }
+        }
+      JSON
+
+      alternate_services = double('services 2',
+        store: double('store 2'),
+        instrumentation: ActiveSupport::Notifications)
+
+      TestNamespace2::Model.configure(
+        schema: alternate_schema,
+        services: alternate_services
+      )
+
+      # Register a subclass of meta in testnamespace2
+      TestNamespace2Meta = Class.new(TestNamespace2::Model::PageMetadata)
+      expect(TestNamespace2::Model.registry['pageMetadata']).to eq(TestNamespace2Meta)
+
+      # When we lookup a model from TestNamespace, we should not get a TestNamespace2 class...
+      allow(store).to receive(:find)
+        .with('blog-post-1', anything)
+        .and_return JSON.parse <<~JSON
+          {
+            "sys": {
+              "id": "blog-post-1",
+              "type": "Entry",
+              "contentType": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "ContentType",
+                  "id": "blogPost"
+                }
+              }
+            },
+            "fields": {
+              "title": {
+                "en-US": "5 Characteristics Of A Godly Man"
+              },
+              "metadata": {
+                "en-US": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "metadata-1"
+                  }
+                }
+              }
+            }
+          }
+        JSON
+      post = TestNamespace::Model::BlogPost.find('blog-post-1')
+      expect(post).to be_a(TestNamespace::Model::BlogPost)
+
+      # When we follow the links, it should not get us a TestNamespace2 class...
+      allow(store).to receive(:find)
+        .with('metadata-1', anything)
+        .and_return JSON.parse <<~JSON
+          {
+            "sys": {
+              "id": "metadata-1",
+              "type": "Entry",
+              "contentType": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "ContentType",
+                  "id": "pageMetadata"
+                }
+              }
+            },
+            "fields": {
+              "metaDescription": {
+                "en-US": "How do I become a Godly man? Learn five characteristics of a Godly man and learn about how to become the man God created you to be."
+              }
+            }
+          }
+        JSON
+      expect(post.metadata).to be_a(TestNamespace::Model::PageMetadata)
+    end
   end
 
   describe '.configure' do
@@ -738,6 +861,12 @@ RSpec.describe WCC::Contentful::ModelAPI do
   end
 
   module TestNamespace # rubocop:disable Style/ClassAndModuleChildren
+    class Model
+      include WCC::Contentful::ModelAPI
+    end
+  end
+
+  module TestNamespace2 # rubocop:disable Style/ClassAndModuleChildren
     class Model
       include WCC::Contentful::ModelAPI
     end

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -548,7 +548,7 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     end
 
     after do
-      WCC::Contentful::Model.class_variable_get('@@registry').clear
+      WCC::Contentful::Model.instance_variable_get('@registry').clear
 
       Object.send(:remove_const, :SUB_MENU) if defined?(SUB_MENU)
       Object.send(:remove_const, :SUB_MENU_BUTTON) if defined?(SUB_MENU_BUTTON)


### PR DESCRIPTION
Fixes a bug where two namespaces were sharing the same registry.

The symptom was that a paper-signs `Page` was instantiating a `Papyrus::PageMetadata`, because the `WCC::Contentful::Model` registry was in fact the same ruby hash as the `Papyrus::Model` registry.  So, when the `Papyrus::PageMetadata` class got eager-loaded, it triggered the `included` hook which put it in the registry, and then the Paper Signs `PageMetadata` never got loaded.