### PR TITLE
Initial support for RichText fields

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/content_type_indexer.rb
+++ b/wcc-contentful/lib/wcc/contentful/content_type_indexer.rb
@@ -137,6 +137,8 @@ module WCC::Contentful
         :Json
       when 'Location'
         :Coordinates
+      when 'RichText'
+        :RichText
       when 'Array'
         find_field_type(field.try(:items) || field['items'])
       when 'Link'

--- a/wcc-contentful/lib/wcc/contentful/indexed_representation.rb
+++ b/wcc-contentful/lib/wcc/contentful/indexed_representation.rb
@@ -103,6 +103,7 @@ module WCC::Contentful
         Boolean
         Json
         Coordinates
+        RichText
         Link
         Asset
       ].freeze

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -2,6 +2,7 @@
 
 require_relative './link'
 require_relative './sys'
+require_relative './rich_text'
 
 module WCC::Contentful
   class ModelBuilder
@@ -95,6 +96,8 @@ module WCC::Contentful
                 #
                 # when :DateTime
                 #   raw_value = Time.parse(raw_value).localtime
+                when :RichText
+                  raw_value = WCC::Contentful::RichText.tokenize(raw_value)
                 when :Int
                   raw_value = Integer(raw_value)
                 when :Float

--- a/wcc-contentful/lib/wcc/contentful/rich_text.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text.rb
@@ -26,7 +26,7 @@ module WCC::Contentful::RichText
       size = Regexp.last_match(1)
       const_get("Heading#{size}").new(tokenize(raw['content']), raw['data'])
     else
-      raise ArgumentError, "Unknown token '#{raw['content']}'"
+      Unknown.tokenize(raw, context)
     end
   end
 
@@ -75,4 +75,9 @@ module WCC::Contentful::RichText
     struct.define_singleton_method(:node_type) { "heading-#{sz}" }
     const_set("Heading#{sz}", struct)
   end
+
+  Unknown =
+    Struct.new(:nodeType, :data, :content) do
+      include WCC::Contentful::RichText::Node
+    end
 end

--- a/wcc-contentful/lib/wcc/contentful/rich_text.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text.rb
@@ -94,7 +94,6 @@ module WCC::Contentful::RichText
         include WCC::Contentful::RichText::Node
       end
     sz = i
-    struct.define_method(:size) { sz }
     struct.define_singleton_method(:node_type) { "heading-#{sz}" }
     const_set("Heading#{sz}", struct)
   end

--- a/wcc-contentful/lib/wcc/contentful/rich_text.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text.rb
@@ -2,32 +2,55 @@
 
 require_relative './rich_text/node'
 
+##
+# This module contains a number of structs representing nodes in a Contentful
+# rich text field.  When the Model layer parses a Rich Text field from
+# Contentful, it is turned into a WCC::Contentful::RichText::Document node.
+# The {WCC::Contentful::RichText::Document#content content} method of this
+# node is an Array containing paragraph, blockquote, entry, and other nodes.
+#
+# The various structs in the RichText object model are designed to mimic the
+# Hash interface, so that the indexing operator `#[]` and the `#dig` method
+# can be used to traverse the data.  The data can also be accessed by the
+# attribute reader methods defined on the structs.  Both of these are considered
+# part of the public API of the model and will not change.
+#
+# In a future release we plan to implement automatic link resolution.  When that
+# happens, the `.data` attribute of embedded entries and assets will return a
+# new class that is able to resolve the `.target` automatically into a full
+# entry or asset.  This future class will still respect the hash accessor methods
+# `#[]`, `#dig`, `#keys`, and `#each`, so it is safe to use those.
 module WCC::Contentful::RichText
+  ##
+  # Recursively converts a raw JSON-parsed hash into the RichText object model.
   def self.tokenize(raw, context = nil)
     return unless raw
     return raw.map { |c| tokenize(c, context) } if raw.is_a?(Array)
 
-    case raw['nodeType']
-    when 'document'
-      Document.tokenize(raw, context)
-    when 'paragraph'
-      Paragraph.tokenize(raw, context)
-    when 'blockquote'
-      Blockquote.tokenize(raw, context)
-    when 'text'
-      Text.new(raw['value'], raw['marks'], raw['data'])
-    when 'embedded-entry-inline'
-      EmbeddedEntryInline.tokenize(raw, context)
-    when 'embedded-entry-block'
-      EmbeddedEntryBlock.tokenize(raw, context)
-    when 'embedded-asset-block'
-      EmbeddedAssetBlock.tokenize(raw, context)
-    when /heading\-(\d+)/
-      size = Regexp.last_match(1)
-      const_get("Heading#{size}").tokenize(raw, context)
-    else
-      Unknown.tokenize(raw, context)
-    end
+    klass =
+      case raw['nodeType']
+      when 'document'
+        Document
+      when 'paragraph'
+        Paragraph
+      when 'blockquote'
+        Blockquote
+      when 'text'
+        Text
+      when 'embedded-entry-inline'
+        EmbeddedEntryInline
+      when 'embedded-entry-block'
+        EmbeddedEntryBlock
+      when 'embedded-asset-block'
+        EmbeddedAssetBlock
+      when /heading\-(\d+)/
+        size = Regexp.last_match(1)
+        const_get("Heading#{size}")
+      else
+        Unknown
+      end
+
+    klass.tokenize(raw, context)
   end
 
   Document =

--- a/wcc-contentful/lib/wcc/contentful/rich_text.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text.rb
@@ -24,7 +24,7 @@ module WCC::Contentful::RichText
       EmbeddedAssetBlock.tokenize(raw, context)
     when /heading\-(\d+)/
       size = Regexp.last_match(1)
-      const_get("Heading#{size}").new(tokenize(raw['content']), raw['data'])
+      const_get("Heading#{size}").tokenize(raw, context)
     else
       Unknown.tokenize(raw, context)
     end

--- a/wcc-contentful/lib/wcc/contentful/rich_text.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module WCC::Contentful::RichText
+  def self.tokenize(raw, context = nil)
+    return unless raw
+    return raw.map { |c| tokenize(c, context) } if raw.is_a?(Array)
+
+    case raw['nodeType']
+    when 'document'
+      Document.new(tokenize(raw['content'], context), raw['data'])
+    when 'paragraph'
+      Paragraph.new(tokenize(raw['content'], context), raw['data'])
+    when 'blockquote'
+      Paragraph.new(tokenize(raw['content'], context), raw['data'])
+    when 'text'
+      Text.new(raw['value'], raw['marks'], raw['data'])
+    when 'embedded-entry-inline'
+      EmbeddedEntryInline.new(tokenize(raw['content'], context), raw['data'])
+    when 'embedded-entry-block'
+      EmbeddedEntryBlock.new(tokenize(raw['content'], context), raw['data'])
+    when 'embedded-asset-block'
+      EmbeddedAssetBlock.new(tokenize(raw['content'], context), raw['data'])
+    when /heading\-(\d+)/
+      Heading.new(Regexp.last_match(1), tokenize(raw['content']), raw['data'])
+    else
+      raise ArgumentError, "Unknown token '#{raw['content']}'"
+    end
+  end
+
+  Document =
+    Struct.new(:content, :data) do
+      def node_type
+        'document'
+      end
+    end
+
+  Paragraph =
+    Struct.new(:content, :data) do
+      def node_type
+        'paragraph'
+      end
+    end
+
+  Blockquote =
+    Struct.new(:content, :data) do
+      def node_type
+        'blockquote'
+      end
+    end
+
+  Text =
+    Struct.new(:value, :marks, :data) do
+      def node_type
+        'text'
+      end
+    end
+
+  EmbeddedEntryInline =
+    Struct.new(:content, :data) do
+      def node_type
+        'embedded-entry-inline'
+      end
+    end
+
+  EmbeddedEntryBlock =
+    Struct.new(:content, :data) do
+      def node_type
+        'embedded-entry-block'
+      end
+    end
+
+  EmbeddedAssetBlock =
+    Struct.new(:content, :data) do
+      def node_type
+        'embedded-asset-block'
+      end
+    end
+
+  Heading =
+    Struct.new(:size, :content, :data) do
+      def node_type
+        "heading-#{size}"
+      end
+    end
+end

--- a/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
@@ -11,8 +11,13 @@ module WCC::Contentful::RichText
     included do
       include Enumerable
 
-      undef_method :[]=
       alias_method :node_type, :nodeType
+
+      # Make the nodes read-only
+      undef_method :[]=
+      members.each do |member|
+        undef_method("#{member}=")
+      end
 
       # Override each so it has a Hash-like interface rather than Struct-like.
       # The goal being to mimic a JSON-parsed hash representation of the raw

--- a/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
@@ -29,7 +29,7 @@ module WCC::Contentful::RichText
         name.demodulize.underscore.dasherize
       end
 
-      def tokenize(raw, _context = nil)
+      def tokenize(raw, context = nil)
         unless raw['nodeType'] == node_type
           raise ArgumentError, "Expected '#{node_type}', got '#{raw['nodeType']}'"
         end
@@ -40,7 +40,7 @@ module WCC::Contentful::RichText
 
             case symbol
             when :content
-              WCC::Contentful::RichText.tokenize(val)
+              WCC::Contentful::RichText.tokenize(val, context)
               # when :data
               # TODO: resolve links...
             else

--- a/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
@@ -23,7 +23,9 @@ module WCC::Contentful::RichText
       # The goal being to mimic a JSON-parsed hash representation of the raw
       def each
         members.map do |key|
-          yield [key, self.[](key)] if block_given?
+          tuple = [key.to_s, self.[](key)]
+          yield tuple if block_given?
+          tuple
         end
       end
     end

--- a/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text/node.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module WCC::Contentful::RichText
+  module Node
+    extend ActiveSupport::Concern
+
+    def keys
+      members.map(&:to_s)
+    end
+
+    included do
+      include Enumerable
+
+      undef_method :[]=
+      alias_method :node_type, :nodeType
+
+      # Override each so it has a Hash-like interface rather than Struct-like.
+      # The goal being to mimic a JSON-parsed hash representation of the raw
+      def each
+        members.map do |key|
+          yield [key, self.[](key)] if block_given?
+        end
+      end
+    end
+
+    class_methods do
+      # Default value for node_type covers most cases
+      def node_type
+        name.demodulize.underscore.dasherize
+      end
+
+      def tokenize(raw, _context = nil)
+        unless raw['nodeType'] == node_type
+          raise ArgumentError, "Expected '#{node_type}', got '#{raw['nodeType']}'"
+        end
+
+        values =
+          members.map do |symbol|
+            val = raw[symbol.to_s]
+
+            case symbol
+            when :content
+              WCC::Contentful::RichText.tokenize(val)
+              # when :data
+              # TODO: resolve links...
+            else
+              val
+            end
+          end
+
+        new(*values)
+      end
+    end
+  end
+end

--- a/wcc-contentful/spec/fixtures/contentful/block-text-with-rich-text.json
+++ b/wcc-contentful/spec/fixtures/contentful/block-text-with-rich-text.json
@@ -1,0 +1,659 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "metadata": {
+        "tags": []
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "xxxxxx"
+          }
+        },
+        "id": "5op6hsU6BYvZCt7S0PjTVv",
+        "type": "Entry",
+        "createdAt": "2019-01-31T17:26:17.449Z",
+        "updatedAt": "2022-04-25T23:20:42.136Z",
+        "environment": {
+          "sys": {
+            "id": "dev",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 12,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "section-block-text"
+          }
+        },
+        "locale": "en-US"
+      },
+      "fields": {
+        "richBody": {
+          "nodeType": "document",
+          "data": {},
+          "content": [
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "## The Meaning Behind Our Name\n### A watermark represents…\n__Authenticity.__ Higher denominations of currency are watermarked to prove they are genuine. In the same way, we want to be people whose lives and relationships are marked by authenticity, integrity, and truth.  ",
+                  "marks": [],
+                  "data": {}
+                },
+                {
+                  "nodeType": "embedded-entry-inline",
+                  "data": {
+                    "target": {
+                      "sys": {
+                        "id": "1D9ASgqWylh9frKnBv8pSM",
+                        "type": "Link",
+                        "linkType": "Entry"
+                      }
+                    }
+                  },
+                  "content": []
+                },
+                {
+                  "nodeType": "text",
+                  "value": "",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "> \"But the goal of our instruction is love from a pure heart and a good conscience and a sincere faith.\" (1 Timothy 1:5)",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "__Excellence.__ Fine paper often features a watermark as evidence of its quality. We strive for excellence, without compromise, in all areas of our ministry and lives, believing that excellence honors God and inspires people.",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "nodeType": "embedded-asset-block",
+              "data": {
+                "target": {
+                  "sys": {
+                    "id": "2mVVl8lJ6HfG9F60lVsonS",
+                    "type": "Link",
+                    "linkType": "Asset"
+                  }
+                }
+              },
+              "content": []
+            },
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "> \"Whatever you do, do your work heartily, as for the Lord rather than for men.\" (Colossians 3:23)",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "nodeType": "embedded-entry-block",
+              "data": {
+                "target": {
+                  "sys": {
+                    "id": "4ueb5DSxGBr6tWCRVLobas",
+                    "type": "Link",
+                    "linkType": "Entry"
+                  }
+                }
+              },
+              "content": []
+            },
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "__A lasting impression.__ The continual presence of water at a certain level leaves a mark long after it is gone. It is our hope, because we have lived faithfully as God's people, that long after we have gone we would make an impact for His Kingdom that would be seen for generations to come.",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "",
+                  "marks": [],
+                  "data": {}
+                },
+                {
+                  "nodeType": "embedded-entry-inline",
+                  "data": {
+                    "target": {
+                      "sys": {
+                        "id": "1cF77xkotNK0jkkHdIajwj",
+                        "type": "Link",
+                        "linkType": "Entry"
+                      }
+                    }
+                  },
+                  "content": []
+                },
+                {
+                  "nodeType": "text",
+                  "value": "",
+                  "marks": [],
+                  "data": {}
+                },
+                {
+                  "nodeType": "embedded-entry-inline",
+                  "data": {
+                    "target": {
+                      "sys": {
+                        "id": "5qF9cDq1P8dgrrHmt9yNBh",
+                        "type": "Link",
+                        "linkType": "Entry"
+                      }
+                    }
+                  },
+                  "content": []
+                },
+                {
+                  "nodeType": "text",
+                  "value": "",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "nodeType": "paragraph",
+              "data": {},
+              "content": [
+                {
+                  "nodeType": "text",
+                  "value": "> \"You are our letter, written in our hearts, known and read by all men.\" (2 Corinthians 3:2)",
+                  "marks": [],
+                  "data": {}
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "includes": {
+    "Entry": [
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "1D9ASgqWylh9frKnBv8pSM",
+          "type": "Entry",
+          "createdAt": "2022-03-10T22:44:21.109Z",
+          "updatedAt": "2022-03-10T22:44:21.109Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menuButton"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "text": "This is dallas"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "1cF77xkotNK0jkkHdIajwj",
+          "type": "Entry",
+          "createdAt": "2020-04-12T14:34:23.529Z",
+          "updatedAt": "2022-04-08T21:38:06.605Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 4,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "card"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "cardImage": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "2lxKGj91eW0zXj6NuZjj4y"
+            }
+          },
+          "skin": "light",
+          "styles": [
+            "image-only"
+          ],
+          "cardImageExternalHref": "/live"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "2W1dhggs1rzVK8QTqRFcCz",
+          "type": "Entry",
+          "createdAt": "2021-11-16T21:29:15.999Z",
+          "updatedAt": "2021-11-16T21:29:15.999Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menuButton"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "text": "FAQ",
+          "externalLink": "#faq"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "2oCKI9s2jLeNIeCBrdL8or",
+          "type": "Entry",
+          "createdAt": "2021-11-16T21:27:35.256Z",
+          "updatedAt": "2021-11-16T21:27:35.256Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menuButton"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "text": "How To Give",
+          "externalLink": "#online",
+          "style": "default"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "3Zo9TL1IhC436YKzMK8ZzO",
+          "type": "Entry",
+          "createdAt": "2021-11-16T21:29:38.998Z",
+          "updatedAt": "2021-11-16T21:29:38.998Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menuButton"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "text": "Contact",
+          "externalLink": "#contact",
+          "style": "default"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "4WuWFbRJ4Crsls2kyNlqGY",
+          "type": "Entry",
+          "createdAt": "2021-11-16T21:30:10.060Z",
+          "updatedAt": "2021-11-16T21:42:58.409Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 3,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menuButton"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "text": "Give To Watermark",
+          "externalLink": "https://pushpay.com/g/watermark?src=hpp",
+          "style": "btn-primary"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "4ueb5DSxGBr6tWCRVLobas",
+          "type": "Entry",
+          "createdAt": "2021-11-16T21:30:27.314Z",
+          "updatedAt": "2022-01-21T17:47:22.306Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 5,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "menu"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "name": " ",
+          "items": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "2oCKI9s2jLeNIeCBrdL8or"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "2W1dhggs1rzVK8QTqRFcCz"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "3Zo9TL1IhC436YKzMK8ZzO"
+              }
+            },
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "4WuWFbRJ4Crsls2kyNlqGY"
+              }
+            }
+          ],
+          "style": "across-the-top"
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "5qF9cDq1P8dgrrHmt9yNBh",
+          "type": "Entry",
+          "createdAt": "2020-04-12T15:52:33.938Z",
+          "updatedAt": "2022-04-08T21:37:29.512Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 11,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "card"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "description": "### Service Times\n__Watermark Dallas__\nSaturday, April 3 at 4 PM\nSunday, April 4 at 9 and 11:15 AM\n\n__En Español__ \nDomingo 11:15 AM en la Capilla\n\n- Kids Ministry for preschool and elementary available at all services. \n- See our [health and safety guidelines](/covid19). \n- Plan your [visit](/visit) with information on parking, driving directions, and more. \n\n[Register For Easter Kids Ministry](/events/4421){:.btn .btn-info}\n\n[Download the Invitation](//assets.ctfassets.net/xxxxxx/45VsnHZ9RIzxLtaMeZNtnv/919b522c1e957b19f000430ed1e5f212/Easter21_Invite_WEB_TG.pdf){: .btn .btn-link}\n",
+          "skin": "blue",
+          "styles": [
+            "text-only"
+          ]
+        }
+      }
+    ],
+    "Asset": [
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "2lxKGj91eW0zXj6NuZjj4y",
+          "type": "Asset",
+          "createdAt": "2021-03-04T21:29:49.015Z",
+          "updatedAt": "2021-03-04T21:29:49.015Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 1,
+          "locale": "en-US"
+        },
+        "fields": {
+          "title": "EASTER21 Web 1920X1080",
+          "file": {
+            "url": "//images.ctfassets.net/xxxxxx/2lxKGj91eW0zXj6NuZjj4y/8e4bb96b480c46918de68c51c9631e31/EASTER21_Web_1920X1080.jpg",
+            "details": {
+              "size": 435701,
+              "image": {
+                "width": 1920,
+                "height": 1080
+              }
+            },
+            "fileName": "EASTER21_Web_1920X1080.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      },
+      {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "xxxxxx"
+            }
+          },
+          "id": "2mVVl8lJ6HfG9F60lVsonS",
+          "type": "Asset",
+          "createdAt": "2022-02-23T20:08:13.420Z",
+          "updatedAt": "2022-02-23T20:08:13.420Z",
+          "environment": {
+            "sys": {
+              "id": "dev",
+              "type": "Link",
+              "linkType": "Environment"
+            }
+          },
+          "revision": 1,
+          "locale": "en-US"
+        },
+        "fields": {
+          "title": "WMM WebpageMobile GIFV6",
+          "description": "",
+          "file": {
+            "url": "//images.ctfassets.net/xxxxxx/2mVVl8lJ6HfG9F60lVsonS/428c15bb03703530c2bf5104f0808f87/WMM_WebpageMobile_GIFV6.gif",
+            "details": {
+              "size": 1159312,
+              "image": {
+                "width": 1080,
+                "height": 1350
+              }
+            },
+            "fileName": "WMM_WebpageMobile_GIFV6.gif",
+            "contentType": "image/gif"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/wcc-contentful/spec/fixtures/contentful/block-text-with-rich-text.json
+++ b/wcc-contentful/spec/fixtures/contentful/block-text-with-rich-text.json
@@ -15,13 +15,13 @@
           "sys": {
             "type": "Link",
             "linkType": "Space",
-            "id": "xxxxxx"
+            "id": "hw5pse7y1ojx"
           }
         },
         "id": "5op6hsU6BYvZCt7S0PjTVv",
         "type": "Entry",
         "createdAt": "2019-01-31T17:26:17.449Z",
-        "updatedAt": "2022-04-25T23:20:42.136Z",
+        "updatedAt": "2022-04-26T17:28:23.370Z",
         "environment": {
           "sys": {
             "id": "dev",
@@ -29,189 +29,277 @@
             "linkType": "Environment"
           }
         },
-        "revision": 12,
+        "revision": 13,
         "contentType": {
           "sys": {
             "type": "Link",
             "linkType": "ContentType",
             "id": "section-block-text"
           }
-        },
-        "locale": "en-US"
+        }
       },
       "fields": {
+        "body": {
+          "en-US": "test"
+        },
         "richBody": {
-          "nodeType": "document",
-          "data": {},
-          "content": [
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "## The Meaning Behind Our Name\n### A watermark represents…\n__Authenticity.__ Higher denominations of currency are watermarked to prove they are genuine. In the same way, we want to be people whose lives and relationships are marked by authenticity, integrity, and truth.  ",
-                  "marks": [],
-                  "data": {}
-                },
-                {
-                  "nodeType": "embedded-entry-inline",
-                  "data": {
-                    "target": {
-                      "sys": {
-                        "id": "1D9ASgqWylh9frKnBv8pSM",
-                        "type": "Link",
-                        "linkType": "Entry"
-                      }
-                    }
-                  },
-                  "content": []
-                },
-                {
-                  "nodeType": "text",
-                  "value": "",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "> \"But the goal of our instruction is love from a pure heart and a good conscience and a sincere faith.\" (1 Timothy 1:5)",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "__Excellence.__ Fine paper often features a watermark as evidence of its quality. We strive for excellence, without compromise, in all areas of our ministry and lives, believing that excellence honors God and inspires people.",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "nodeType": "embedded-asset-block",
-              "data": {
-                "target": {
-                  "sys": {
-                    "id": "2mVVl8lJ6HfG9F60lVsonS",
-                    "type": "Link",
-                    "linkType": "Asset"
+          "en-US": {
+            "nodeType": "document",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "heading-2",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "The Meaning Behind Our Name",
+                    "marks": [],
+                    "data": {}
                   }
-                }
+                ]
               },
-              "content": []
-            },
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "> \"Whatever you do, do your work heartily, as for the Lord rather than for men.\" (Colossians 3:23)",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "nodeType": "embedded-entry-block",
-              "data": {
-                "target": {
-                  "sys": {
-                    "id": "4ueb5DSxGBr6tWCRVLobas",
-                    "type": "Link",
-                    "linkType": "Entry"
+              {
+                "nodeType": "heading-3",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "A watermark represents…",
+                    "marks": [],
+                    "data": {}
                   }
-                }
+                ]
               },
-              "content": []
-            },
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "__A lasting impression.__ The continual presence of water at a certain level leaves a mark long after it is gone. It is our hope, because we have lived faithfully as God's people, that long after we have gone we would make an impact for His Kingdom that would be seen for generations to come.",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "",
-                  "marks": [],
-                  "data": {}
-                },
-                {
-                  "nodeType": "embedded-entry-inline",
-                  "data": {
-                    "target": {
-                      "sys": {
-                        "id": "1cF77xkotNK0jkkHdIajwj",
-                        "type": "Link",
-                        "linkType": "Entry"
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Authenticity.",
+                    "marks": [
+                      {
+                        "type": "italic"
                       }
-                    }
+                    ],
+                    "data": {}
                   },
-                  "content": []
-                },
-                {
-                  "nodeType": "text",
-                  "value": "",
-                  "marks": [],
-                  "data": {}
-                },
-                {
-                  "nodeType": "embedded-entry-inline",
-                  "data": {
-                    "target": {
-                      "sys": {
-                        "id": "5qF9cDq1P8dgrrHmt9yNBh",
-                        "type": "Link",
-                        "linkType": "Entry"
+                  {
+                    "nodeType": "text",
+                    "value": " Higher denominations of currency are watermarked to prove they are genuine. In the same way, we want to be people whose lives and relationships are marked by authenticity, integrity, and truth.  ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "embedded-entry-inline",
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "1D9ASgqWylh9frKnBv8pSM",
+                          "type": "Link",
+                          "linkType": "Entry"
+                        }
                       }
-                    }
+                    },
+                    "content": []
                   },
-                  "content": []
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              },
+              {
+                "nodeType": "blockquote",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "paragraph",
+                    "data": {},
+                    "content": [
+                      {
+                        "nodeType": "text",
+                        "value": "\"But the goal of our instruction is love from a pure heart and a good conscience and a sincere faith.\" (1 Timothy 1:5)",
+                        "marks": [],
+                        "data": {}
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Excellence.",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " Fine paper often features a watermark as evidence of its quality. We strive for excellence, without compromise, in all areas of our ministry and lives, believing that excellence honors God and inspires people.",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              },
+              {
+                "nodeType": "embedded-asset-block",
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "2mVVl8lJ6HfG9F60lVsonS",
+                      "type": "Link",
+                      "linkType": "Asset"
+                    }
+                  }
                 },
-                {
-                  "nodeType": "text",
-                  "value": "",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "nodeType": "paragraph",
-              "data": {},
-              "content": [
-                {
-                  "nodeType": "text",
-                  "value": "> \"You are our letter, written in our hearts, known and read by all men.\" (2 Corinthians 3:2)",
-                  "marks": [],
-                  "data": {}
-                }
-              ]
-            }
-          ]
+                "content": []
+              },
+              {
+                "nodeType": "blockquote",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "paragraph",
+                    "data": {},
+                    "content": [
+                      {
+                        "nodeType": "text",
+                        "value": "\"Whatever you do, do your work heartily, as for the Lord rather than for men.\" (Colossians 3:23)",
+                        "marks": [],
+                        "data": {}
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "nodeType": "embedded-entry-block",
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "4ueb5DSxGBr6tWCRVLobas",
+                      "type": "Link",
+                      "linkType": "Entry"
+                    }
+                  }
+                },
+                "content": []
+              },
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "A lasting impression.",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " The continual presence of water at a certain level leaves a mark long after it is gone. It is our hope, because we have lived faithfully as God's people, that long after we have gone we would make an impact for His Kingdom that would be seen for generations to come.",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              },
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "embedded-entry-inline",
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "1cF77xkotNK0jkkHdIajwj",
+                          "type": "Link",
+                          "linkType": "Entry"
+                        }
+                      }
+                    },
+                    "content": []
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "embedded-entry-inline",
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "5qF9cDq1P8dgrrHmt9yNBh",
+                          "type": "Link",
+                          "linkType": "Entry"
+                        }
+                      }
+                    },
+                    "content": []
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              },
+              {
+                "nodeType": "blockquote",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "paragraph",
+                    "data": {},
+                    "content": [
+                      {
+                        "nodeType": "text",
+                        "value": "\"You are our letter, written in our hearts, known and read by all men.\" (2 Corinthians 3:2)",
+                        "marks": [],
+                        "data": {}
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          }
         }
       }
     }
@@ -227,7 +315,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "1D9ASgqWylh9frKnBv8pSM",
@@ -248,11 +336,12 @@
               "linkType": "ContentType",
               "id": "menuButton"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "text": "This is dallas"
+          "text": {
+            "en-US": "This is dallas"
+          }
         }
       },
       {
@@ -264,7 +353,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "1cF77xkotNK0jkkHdIajwj",
@@ -285,22 +374,29 @@
               "linkType": "ContentType",
               "id": "card"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
           "cardImage": {
-            "sys": {
-              "type": "Link",
-              "linkType": "Asset",
-              "id": "2lxKGj91eW0zXj6NuZjj4y"
+            "en-US": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Asset",
+                "id": "2lxKGj91eW0zXj6NuZjj4y"
+              }
             }
           },
-          "skin": "light",
-          "styles": [
-            "image-only"
-          ],
-          "cardImageExternalHref": "/live"
+          "skin": {
+            "en-US": "light"
+          },
+          "styles": {
+            "en-US": [
+              "image-only"
+            ]
+          },
+          "cardImageExternalHref": {
+            "en-US": "/live"
+          }
         }
       },
       {
@@ -312,7 +408,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "2W1dhggs1rzVK8QTqRFcCz",
@@ -333,12 +429,15 @@
               "linkType": "ContentType",
               "id": "menuButton"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "text": "FAQ",
-          "externalLink": "#faq"
+          "text": {
+            "en-US": "FAQ"
+          },
+          "externalLink": {
+            "en-US": "#faq"
+          }
         }
       },
       {
@@ -350,7 +449,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "2oCKI9s2jLeNIeCBrdL8or",
@@ -371,13 +470,18 @@
               "linkType": "ContentType",
               "id": "menuButton"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "text": "How To Give",
-          "externalLink": "#online",
-          "style": "default"
+          "text": {
+            "en-US": "How To Give"
+          },
+          "externalLink": {
+            "en-US": "#online"
+          },
+          "style": {
+            "en-US": "default"
+          }
         }
       },
       {
@@ -389,7 +493,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "3Zo9TL1IhC436YKzMK8ZzO",
@@ -410,13 +514,18 @@
               "linkType": "ContentType",
               "id": "menuButton"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "text": "Contact",
-          "externalLink": "#contact",
-          "style": "default"
+          "text": {
+            "en-US": "Contact"
+          },
+          "externalLink": {
+            "en-US": "#contact"
+          },
+          "style": {
+            "en-US": "default"
+          }
         }
       },
       {
@@ -428,7 +537,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "4WuWFbRJ4Crsls2kyNlqGY",
@@ -449,13 +558,18 @@
               "linkType": "ContentType",
               "id": "menuButton"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "text": "Give To Watermark",
-          "externalLink": "https://pushpay.com/g/watermark?src=hpp",
-          "style": "btn-primary"
+          "text": {
+            "en-US": "Give To Watermark"
+          },
+          "externalLink": {
+            "en-US": "https://pushpay.com/g/watermark?src=hpp"
+          },
+          "style": {
+            "en-US": "btn-primary"
+          }
         }
       },
       {
@@ -467,7 +581,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "4ueb5DSxGBr6tWCRVLobas",
@@ -488,42 +602,47 @@
               "linkType": "ContentType",
               "id": "menu"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "name": " ",
-          "items": [
-            {
-              "sys": {
-                "type": "Link",
-                "linkType": "Entry",
-                "id": "2oCKI9s2jLeNIeCBrdL8or"
+          "name": {
+            "en-US": " "
+          },
+          "items": {
+            "en-US": [
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "2oCKI9s2jLeNIeCBrdL8or"
+                }
+              },
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "2W1dhggs1rzVK8QTqRFcCz"
+                }
+              },
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "3Zo9TL1IhC436YKzMK8ZzO"
+                }
+              },
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "4WuWFbRJ4Crsls2kyNlqGY"
+                }
               }
-            },
-            {
-              "sys": {
-                "type": "Link",
-                "linkType": "Entry",
-                "id": "2W1dhggs1rzVK8QTqRFcCz"
-              }
-            },
-            {
-              "sys": {
-                "type": "Link",
-                "linkType": "Entry",
-                "id": "3Zo9TL1IhC436YKzMK8ZzO"
-              }
-            },
-            {
-              "sys": {
-                "type": "Link",
-                "linkType": "Entry",
-                "id": "4WuWFbRJ4Crsls2kyNlqGY"
-              }
-            }
-          ],
-          "style": "across-the-top"
+            ]
+          },
+          "style": {
+            "en-US": "across-the-top"
+          }
         }
       },
       {
@@ -535,7 +654,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "5qF9cDq1P8dgrrHmt9yNBh",
@@ -556,15 +675,20 @@
               "linkType": "ContentType",
               "id": "card"
             }
-          },
-          "locale": "en-US"
+          }
         },
         "fields": {
-          "description": "### Service Times\n__Watermark Dallas__\nSaturday, April 3 at 4 PM\nSunday, April 4 at 9 and 11:15 AM\n\n__En Español__ \nDomingo 11:15 AM en la Capilla\n\n- Kids Ministry for preschool and elementary available at all services. \n- See our [health and safety guidelines](/covid19). \n- Plan your [visit](/visit) with information on parking, driving directions, and more. \n\n[Register For Easter Kids Ministry](/events/4421){:.btn .btn-info}\n\n[Download the Invitation](//assets.ctfassets.net/xxxxxx/45VsnHZ9RIzxLtaMeZNtnv/919b522c1e957b19f000430ed1e5f212/Easter21_Invite_WEB_TG.pdf){: .btn .btn-link}\n",
-          "skin": "blue",
-          "styles": [
-            "text-only"
-          ]
+          "description": {
+            "en-US": "### Service Times\n__Watermark Dallas__\nSaturday, April 3 at 4 PM\nSunday, April 4 at 9 and 11:15 AM\n\n__En Español__ \nDomingo 11:15 AM en la Capilla\n\n- Kids Ministry for preschool and elementary available at all services. \n- See our [health and safety guidelines](/covid19). \n- Plan your [visit](/visit) with information on parking, driving directions, and more. \n\n[Register For Easter Kids Ministry](/events/4421){:.btn .btn-info}\n\n[Download the Invitation](//assets.ctfassets.net/hw5pse7y1ojx/45VsnHZ9RIzxLtaMeZNtnv/919b522c1e957b19f000430ed1e5f212/Easter21_Invite_WEB_TG.pdf){: .btn .btn-link}\n"
+          },
+          "skin": {
+            "en-US": "blue"
+          },
+          "styles": {
+            "en-US": [
+              "text-only"
+            ]
+          }
         }
       }
     ],
@@ -578,7 +702,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "2lxKGj91eW0zXj6NuZjj4y",
@@ -592,22 +716,25 @@
               "linkType": "Environment"
             }
           },
-          "revision": 1,
-          "locale": "en-US"
+          "revision": 1
         },
         "fields": {
-          "title": "EASTER21 Web 1920X1080",
+          "title": {
+            "en-US": "EASTER21 Web 1920X1080"
+          },
           "file": {
-            "url": "//images.ctfassets.net/xxxxxx/2lxKGj91eW0zXj6NuZjj4y/8e4bb96b480c46918de68c51c9631e31/EASTER21_Web_1920X1080.jpg",
-            "details": {
-              "size": 435701,
-              "image": {
-                "width": 1920,
-                "height": 1080
-              }
-            },
-            "fileName": "EASTER21_Web_1920X1080.jpg",
-            "contentType": "image/jpeg"
+            "en-US": {
+              "url": "//images.ctfassets.net/hw5pse7y1ojx/2lxKGj91eW0zXj6NuZjj4y/8e4bb96b480c46918de68c51c9631e31/EASTER21_Web_1920X1080.jpg",
+              "details": {
+                "size": 435701,
+                "image": {
+                  "width": 1920,
+                  "height": 1080
+                }
+              },
+              "fileName": "EASTER21_Web_1920X1080.jpg",
+              "contentType": "image/jpeg"
+            }
           }
         }
       },
@@ -620,7 +747,7 @@
             "sys": {
               "type": "Link",
               "linkType": "Space",
-              "id": "xxxxxx"
+              "id": "hw5pse7y1ojx"
             }
           },
           "id": "2mVVl8lJ6HfG9F60lVsonS",
@@ -634,23 +761,28 @@
               "linkType": "Environment"
             }
           },
-          "revision": 1,
-          "locale": "en-US"
+          "revision": 1
         },
         "fields": {
-          "title": "WMM WebpageMobile GIFV6",
-          "description": "",
+          "title": {
+            "en-US": "WMM WebpageMobile GIFV6"
+          },
+          "description": {
+            "en-US": ""
+          },
           "file": {
-            "url": "//images.ctfassets.net/xxxxxx/2mVVl8lJ6HfG9F60lVsonS/428c15bb03703530c2bf5104f0808f87/WMM_WebpageMobile_GIFV6.gif",
-            "details": {
-              "size": 1159312,
-              "image": {
-                "width": 1080,
-                "height": 1350
-              }
-            },
-            "fileName": "WMM_WebpageMobile_GIFV6.gif",
-            "contentType": "image/gif"
+            "en-US": {
+              "url": "//images.ctfassets.net/hw5pse7y1ojx/2mVVl8lJ6HfG9F60lVsonS/428c15bb03703530c2bf5104f0808f87/WMM_WebpageMobile_GIFV6.gif",
+              "details": {
+                "size": 1159312,
+                "image": {
+                  "width": 1080,
+                  "height": 1350
+                }
+              },
+              "fileName": "WMM_WebpageMobile_GIFV6.gif",
+              "contentType": "image/gif"
+            }
           }
         }
       }

--- a/wcc-contentful/spec/fixtures/contentful/content_types_rich_text.json
+++ b/wcc-contentful/spec/fixtures/contentful/content_types_rich_text.json
@@ -1,0 +1,415 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "id": "section-block-text",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Section: Block Text",
+      "description": "Markdown free-text block",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "richBody",
+          "name": "RichBody",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "enabledMarks": [
+                "bold",
+                "italic",
+                "underline",
+                "code"
+              ],
+              "message": "Only bold, italic, underline, and code marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-entry-block",
+                "embedded-asset-block",
+                "table",
+                "hyperlink",
+                "entry-hyperlink",
+                "asset-hyperlink",
+                "embedded-entry-inline"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed"
+            },
+            {
+              "nodes": {
+                "embedded-entry-block": [
+                  {
+                    "linkContentType": [
+                      "menu",
+                      "section-card-deck"
+                    ],
+                    "message": null
+                  }
+                ],
+                "embedded-entry-inline": [
+                  {
+                    "linkContentType": [
+                      "card",
+                      "codeButton",
+                      "menuButton"
+                    ],
+                    "message": null
+                  }
+                ],
+                "entry-hyperlink": [
+                  {
+                    "linkContentType": [
+                      "page"
+                    ],
+                    "message": null
+                  }
+                ]
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "page",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Page",
+      "description": "A page describes a collection of sections that correspondto a URL slug",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "regexp": {
+                "pattern": "^(\\/|(?:\\/[a-z\\d](?:[a-z\\d_\\-]|(?:\\%[\\dA-Z]{2}))*)+)$"
+              },
+              "message": "The slug must look like the path part of a URL and begin with a forward slash, example: '/my-page-slug'"
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "card",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Card",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "cardImage",
+          "name": "Card Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkMimetypeGroup": [
+                "image"
+              ]
+            },
+            {
+              "assetFileSize": {
+                "min": null,
+                "max": 20971520
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "menu",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Menu",
+      "description": "A Menu contains a number of Menu Buttons or other Menus, which will be rendered as drop-downs.",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title (Contentful Only)",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "items",
+          "name": "Items",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "menuButton"
+                ],
+                "message": "The items must be either buttons or drop-down menus."
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "section-card-deck",
+        "type": "ContentType"
+      },
+      "displayField": "internalTitle",
+      "name": "Section: Card Deck",
+      "description": "",
+      "fields": [
+        {
+          "id": "internalTitle",
+          "name": "Internal Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": true
+        },
+        {
+          "id": "cards",
+          "name": "Cards",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "card"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    }
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "section-block-text",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "richBody",
+          "widgetId": "richTextEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "page",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "slug",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "card",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "cardImage",
+          "widgetId": "assetLinkEditor"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "menu",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "items",
+          "settings": {
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "contentType": {
+          "sys": {
+            "id": "section-card-deck",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "cards",
+          "settings": {
+            "bulkEditing": false
+          },
+          "widgetId": "entryLinksEditor"
+        },
+        {
+          "fieldId": "internalTitle",
+          "widgetId": "singleLine"
+        }
+      ]
+    }
+  ]
+}

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -455,6 +455,34 @@ RSpec.describe WCC::Contentful::ModelBuilder do
       expect(homepage.favicons[1].file.fileName).to eq('favicon-32x32.png')
       expect(homepage.favicons.length).to eq(3)
     end
+
+    describe 'rich text' do
+      let(:store) { double('store') }
+      let(:types) {
+        WCC::Contentful::ContentTypeIndexer
+          .load(path_to_fixture('contentful/content_types_rich_text.json'))
+          .types
+      }
+      let(:fixture) { JSON.parse(load_fixture('contentful/block-text-with-rich-text.json')) }
+      let(:block_text) {
+        fixture.dig('items', 0)
+      }
+
+      context 'unresolved' do
+        it 'has content blocks' do
+          allow(store).to receive(:find_by)
+            .and_return(block_text)
+
+          @schema = subject.build_models
+
+          # act
+          block_text = WCC::Contentful::Model::SectionBlockText.find_by(id: '5op6hsU6BYvZCt7S0PjTVv')
+
+          # assert
+          expect(block_text.rich_body['content'].length).to eq(9)
+        end
+      end
+    end
   end
 
   describe 'model subclasses' do

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe WCC::Contentful::ModelBuilder do
       expect(homepage.favicons.length).to eq(3)
     end
 
-    describe 'rich text', focus: true do
+    describe 'rich text' do
       let(:store) { double('store') }
       let(:types) {
         WCC::Contentful::ContentTypeIndexer
@@ -490,19 +490,23 @@ RSpec.describe WCC::Contentful::ModelBuilder do
               'paragraph', 'paragraph', 'blockquote', 'paragraph'
             ]
           )
-        end
-
-        it 'can dig to deep nodes' do
-          # act
-          block_text = WCC::Contentful::Model::SectionBlockText.find_by(id: '5op6hsU6BYvZCt7S0PjTVv')
-
-          # assert
-          expect(
-            block_text.rich_body.dig('content', 2, 'content', 2, 'data', 'target', 'sys', 'id')
-          ).to eq('1D9ASgqWylh9frKnBv8pSM')
-          expect(
-            block_text.rich_body['content'][2]['content'][2]['data']['target']['sys']['linkType']
-          ).to eq('Entry')
+          classes = block_text.rich_body['content'].map(&:class)
+          expect(classes).to eq(
+            [
+              WCC::Contentful::RichText::Heading2,
+              WCC::Contentful::RichText::Heading3,
+              WCC::Contentful::RichText::Paragraph,
+              WCC::Contentful::RichText::Blockquote,
+              WCC::Contentful::RichText::Paragraph,
+              WCC::Contentful::RichText::EmbeddedAssetBlock,
+              WCC::Contentful::RichText::Blockquote,
+              WCC::Contentful::RichText::EmbeddedEntryBlock,
+              WCC::Contentful::RichText::Paragraph,
+              WCC::Contentful::RichText::Paragraph,
+              WCC::Contentful::RichText::Blockquote,
+              WCC::Contentful::RichText::Paragraph
+            ]
+          )
         end
       end
     end

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -56,400 +56,404 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     expect(WCC::Contentful::Model.constants(false)).to include(:Page)
   end
 
-  it 'finds types by ID' do
-    @schema = subject.build_models
-
-    # act
-    main_menu = WCC::Contentful::Model.find('FNlqULSV0sOy4IoGmyWOW')
-
-    # assert
-    expect(main_menu).to be_instance_of(WCC::Contentful::Model::Menu)
-    expect(main_menu.id).to eq('FNlqULSV0sOy4IoGmyWOW')
-    expect(main_menu.created_at).to eq(Time.parse('2018-02-12T20:09:38.819Z'))
-    expect(main_menu.updated_at).to eq(Time.parse('2018-02-12T21:59:43.653Z'))
-    expect(main_menu.revision).to eq(2)
-    expect(main_menu.space).to eq(contentful_space_id)
-
-    expect(main_menu.name).to eq('Main Menu')
-  end
-
-  it 'finds by ID on derived class' do
-    @schema = subject.build_models
-
-    # act
-    main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
-
-    # assert
-    expect(main_menu).to be_instance_of(WCC::Contentful::Model::Menu)
-    expect(main_menu.id).to eq('FNlqULSV0sOy4IoGmyWOW')
-    expect(main_menu.created_at).to eq(Time.parse('2018-02-12T20:09:38.819Z'))
-    expect(main_menu.updated_at).to eq(Time.parse('2018-02-12T21:59:43.653Z'))
-    expect(main_menu.revision).to eq(2)
-    expect(main_menu.space).to eq(contentful_space_id)
-
-    expect(main_menu.name).to eq('Main Menu')
-  end
-
-  it 'instruments find' do
-    @schema = subject.build_models
-
-    # act
-    expect {
-      WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
-    }.to instrument('find.model.contentful.wcc')
-  end
-
-  it 'returns nil if cannot find ID' do
-    @schema = subject.build_models
-
-    # act
-    main_menu = WCC::Contentful::Model::Menu.find('asdf')
-
-    # assert
-    expect(main_menu).to be_nil
-  end
-
-  it 'errors fast if ID is wrong content type' do
-    @schema = subject.build_models
-
-    # act
-    expect {
-      _actually_a_menu = WCC::Contentful::Model::Page.find('FNlqULSV0sOy4IoGmyWOW')
-    }.to raise_error(ArgumentError)
-  end
-
-  it 'finds types by content type' do
-    @schema = subject.build_models
-
-    # act
-    menu_items = WCC::Contentful::Model::MenuButton.find_all
-
-    # assert
-    expect(menu_items.count).to eq(11)
-    expect(menu_items.map(&:id).sort).to eq(
-      %w[
-        1EjBdAgOOgAQKAggQoY2as
-        1IJEXB4AKEqQYEm4WuceG2
-        1TikjmGeSIisEWoC4CwokQ
-        2X7Pm2VQmQyAWK0y2wy8me
-        3Jmk4yOwhOY0yKsI6mAQ2a
-        3bZRv5ISCkui6kguIwM2U0
-        4Gye0ybf2EiWCgSyEg0cyE
-        4W3ADPamKsMOg6Gu8aGwOu
-        4tMhra8IAwcEoKS6QSQYcc
-        5NBhDw3i2kUqSwqYok4YQO
-        ZosJIuGfgkky0cA2GsymW
-      ]
-    )
-    menu_item = menu_items.find { |i| i.id == '4tMhra8IAwcEoKS6QSQYcc' }
-    expect(menu_item.custom_button_css).to eq(
-      [
-        'text-decoration: underline;',
-        'color: brown;'
-      ]
-    )
-  end
-
-  it 'finds with filter' do
-    @schema = subject.build_models
-
-    # act
-    menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'custom')
-
-    # assert
-    expect(menu_items.count).to eq(2)
-    expect(menu_items.map(&:id).sort).to eq(
-      %w[3bZRv5ISCkui6kguIwM2U0 4tMhra8IAwcEoKS6QSQYcc]
-    )
-  end
-
-  it 'instruments find_all' do
-    @schema = subject.build_models
-
-    # act
-    expect {
-      WCC::Contentful::Model::MenuButton.find_all(button_style: 'custom')
-    }.to instrument('find_all.model.contentful.wcc')
-  end
-
-  it 'returns empty array if find_all finds nothing' do
-    @schema = subject.build_models
-    store_resp = double
-    expect(store).to receive(:find_all).and_return(store_resp)
-    expect(store_resp).to receive(:apply).and_return(store_resp)
-
-    expect(store_resp).to receive(:to_enum).and_return([])
-
-    # act
-    menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'asdf')
-
-    # assert
-    expect(menu_items.to_a).to eq([])
-  end
-
-  it 'delegates #count to the underlying store w/o iterating the enumerable' do
-    @schema = subject.build_models
-    store_resp = double(count: 1234)
-    expect(store).to receive(:find_all).and_return(store_resp)
-    allow(store_resp).to receive(:apply).and_return(store_resp)
-
-    expect(store_resp).to_not receive(:to_enum)
-
-    # act
-    menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'asdf')
-
-    # assert
-    expect(menu_items.count).to eq(1234)
-  end
-
-  it 'finds single item with filter' do
-    @schema = subject.build_models
-
-    # act
-    redirect = WCC::Contentful::Model::Redirect2.find_by(slug: 'mister_roboto')
-
-    # assert
-    expect(redirect).to_not be_nil
-    expect(redirect.pageReference.title).to eq('Conferences')
-  end
-
-  it 'instruments find_by' do
-    @schema = subject.build_models
-
-    # act
-    expect {
-      WCC::Contentful::Model::Redirect2.find_by(slug: 'mister_roboto')
-    }.to instrument('find_by.model.contentful.wcc')
-  end
-
-  it 'returns nil if find_by finds nothing' do
-    @schema = subject.build_models
-
-    # act
-    redirect = WCC::Contentful::Model::Redirect2.find_by(slug: 'asdf')
-
-    # assert
-    expect(redirect).to be_nil
-  end
-
-  it 'resolves numeric fields' do
-    @schema = subject.build_models
-
-    # act
-    faq = WCC::Contentful::Model::Faq.find_all.first
-
-    # assert
-    expect(faq.num_faqs).to eq(2)
-    expect(faq.num_faqs_float).to eq(2.1)
-  end
-
-  it 'resolves json blobs' do
-    @schema = subject.build_models
-
-    # act
-    migration = WCC::Contentful::Model::MigrationHistory.find_all.first
-
-    # assert
-    expect(migration.detail).to be_instance_of(Array)
-    expect(migration.detail[0]).to be_instance_of(OpenStruct)
-    expect(migration.detail.dig(0, 'intent', 'intents')).to include(
-      {
-        'meta' => {
-          'callsite' => {
-            'file' =>
-              '/Users/gburgett/projects/wm/jtj-com/db/migrate/20180219160530_test_migration.ts',
-            'line' => 3
-          },
-          'contentTypeInstanceId' => 'contentType/dog/0'
-        },
-        'type' => 'contentType/create',
-        'payload' => {
-          'contentTypeId' => 'dog'
-        }
-      }
-    )
-  end
-
-  # Note: see code comment inside model_builder.rb for why we do not parse DateTime objects
-  it 'does not parse date times' do
-    @schema = subject.build_models
-
-    # act
-    faq = WCC::Contentful::Model::Faq.find('1nzrZZShhWQsMcey28uOUQ')
-
-    # assert
-    expect(faq.date_of_faq).to be_a String
-    expect(faq.date_of_faq).to eq('2018-02-01')
-  end
-
-  it 'resolves coordinates' do
-    @schema = subject.build_models
-
-    # act
-    faq = WCC::Contentful::Model::Faq.find('1nzrZZShhWQsMcey28uOUQ')
-
-    # assert
-    expect(faq.placeOfFaq.lat).to eq(52.5391688192368)
-    expect(faq.placeOfFaq.lon).to eq(13.4033203125)
-  end
-
-  it 'resolves linked types' do
-    @schema = subject.build_models
-
-    # act
-    main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
-
-    # assert
-    expect(main_menu.hamburger).to be_instance_of(WCC::Contentful::Model::Menu)
-    expect(main_menu.hamburger.items[0]).to be_instance_of(WCC::Contentful::Model::MenuButton)
-    expect(main_menu.hamburger.items[0].link).to be_instance_of(WCC::Contentful::Model::Page)
-    expect(main_menu.hamburger.items[0].link.title).to eq('About')
-  end
-
-  it 'ignores linked types when they can\'t be resolved' do
-    @schema = subject.build_models
-
-    allow(WCC::Contentful::Model).to receive(:find)
-      .and_call_original
-
-    allow(WCC::Contentful::Model).to receive(:find)
-      .with('5NBhDw3i2kUqSwqYok4YQO', any_args)
-      .and_return(nil)
-
-    # act
-    main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
-
-    # assert
-    expect(main_menu.hamburger).to be_instance_of(WCC::Contentful::Model::Menu)
-    expect(main_menu.hamburger.items[1]).to be_instance_of(WCC::Contentful::Model::MenuButton)
-    expect(main_menu.hamburger.items[1].externalLink).to eq('https://www.watermark.org')
-    expect(main_menu.hamburger.items.length).to eq(2)
-  end
-
-  it 'makes ID of linked types accessible' do
-    @schema = subject.build_models
-
-    # act
-    main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
-
-    # assert
-    expect(store).to_not receive(:find)
-    expect(main_menu.hamburger_id).to eq('6y9DftpiYoA4YiKg2CgoUU')
-  end
-
-  it 'makes all IDs of a linked array accessible' do
-    @schema = subject.build_models
-
-    # act
-    side_menu = WCC::Contentful::Model::Menu.find('6y9DftpiYoA4YiKg2CgoUU')
-
-    # assert
-    expect(store).to_not receive(:find)
-    expect(side_menu.items_ids).to eq(
-      %w[
-        1IJEXB4AKEqQYEm4WuceG2
-        5NBhDw3i2kUqSwqYok4YQO
-        4tMhra8IAwcEoKS6QSQYcc
-      ]
-    )
-  end
-
-  it 'stores backreference on linked type context' do
-    @schema = subject.build_models
-
-    # act
-    main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
-
-    # assert
-    hamburger = main_menu.hamburger
-    expect(hamburger.sys.context.backlinks).to eq([main_menu])
-
-    button = hamburger.items[0]
-    expect(button.sys.context.backlinks).to eq([hamburger, main_menu])
-
-    page = button.link
-    expect(page.sys.context.backlinks).to eq([button, hamburger, main_menu])
-  end
-
-  it 'handles nil linked types' do
-    @schema = subject.build_models
-
-    # act
-    ministries_page = WCC::Contentful::Model::Page.find('JhYhSfZPAOMqsaK8cYOUK')
-
-    # assert
-    expect(ministries_page.sub_menu).to be_nil
-  end
-
-  it 'linked arrays are empty when no links found' do
-    @schema = subject.build_models
-
-    # act
-    privacy_policy_page = WCC::Contentful::Model::Page.find('1tPGouM76soIsM2e0uikgw')
-
-    # assert
-    expect(privacy_policy_page.sections).to eq([])
-  end
-
-  it 'resolves linked assets' do
-    @schema = subject.build_models
-
-    # act
-    homepage = WCC::Contentful::Model::Homepage.find_all.first
-
-    # assert
-    expect(homepage.hero_image).to be_instance_of(WCC::Contentful::Model::Asset)
-    expect(homepage.hero_image.file).to be_a(OpenStruct)
-    expect(homepage.hero_image.title).to eq('worship')
-    expect(homepage.hero_image.file['url']).to eq("//images.contentful.com/#{contentful_space_id}/" \
-      '572YrsdGZGo0sw2Www2Si8/545f53511e362a78a8f34e1837868256/worship.jpg')
-    expect(homepage.hero_image.file['contentType']).to eq('image/jpeg')
-
-    expect(homepage.favicons).to be_a(Array)
-    expect(homepage.favicons.length).to eq(4)
-    expect(homepage.favicons[0]).to be_instance_of(WCC::Contentful::Model::Asset)
-    expect(homepage.favicons[0].file.fileName).to eq('favicon.ico')
-  end
-
-  it 'ignores linked assets when they can\'t be resolved' do
-    @schema = subject.build_models
-
-    allow(WCC::Contentful::Model).to receive(:find)
-      .and_call_original
-
-    allow(WCC::Contentful::Model).to receive(:find)
-      .with('1MsOLBrDwEUAUIuMY8Ys6o', any_args)
-      .and_return(nil)
-
-    # act
-    homepage = WCC::Contentful::Model::Homepage.find_all.first
-
-    # assert
-    expect(homepage.favicons).to be_a(Array)
-    expect(homepage.favicons[1]).to be_instance_of(WCC::Contentful::Model::Asset)
-    expect(homepage.favicons[1].file.fileName).to eq('favicon-32x32.png')
-    expect(homepage.favicons.length).to eq(3)
-  end
-
-  context 'with options' do
-    it 'find_by preloads links when include param > 0' do
+  describe 'static methods' do
+    it 'finds types by ID' do
       @schema = subject.build_models
 
       # act
-      home_page = WCC::Contentful::Model::Homepage.find_by(
-        options: { include: 1 },
-        site_title: 'Watermark Resources'
-      )
+      main_menu = WCC::Contentful::Model.find('FNlqULSV0sOy4IoGmyWOW')
 
       # assert
-      # no on-demand link resolution, it's already been resolved
+      expect(main_menu).to be_instance_of(WCC::Contentful::Model::Menu)
+      expect(main_menu.id).to eq('FNlqULSV0sOy4IoGmyWOW')
+      expect(main_menu.created_at).to eq(Time.parse('2018-02-12T20:09:38.819Z'))
+      expect(main_menu.updated_at).to eq(Time.parse('2018-02-12T21:59:43.653Z'))
+      expect(main_menu.revision).to eq(2)
+      expect(main_menu.space).to eq(contentful_space_id)
+
+      expect(main_menu.name).to eq('Main Menu')
+    end
+
+    it 'finds by ID on derived class' do
+      @schema = subject.build_models
+
+      # act
+      main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+
+      # assert
+      expect(main_menu).to be_instance_of(WCC::Contentful::Model::Menu)
+      expect(main_menu.id).to eq('FNlqULSV0sOy4IoGmyWOW')
+      expect(main_menu.created_at).to eq(Time.parse('2018-02-12T20:09:38.819Z'))
+      expect(main_menu.updated_at).to eq(Time.parse('2018-02-12T21:59:43.653Z'))
+      expect(main_menu.revision).to eq(2)
+      expect(main_menu.space).to eq(contentful_space_id)
+
+      expect(main_menu.name).to eq('Main Menu')
+    end
+
+    it 'instruments find' do
+      @schema = subject.build_models
+
+      # act
+      expect {
+        WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+      }.to instrument('find.model.contentful.wcc')
+    end
+
+    it 'returns nil if cannot find ID' do
+      @schema = subject.build_models
+
+      # act
+      main_menu = WCC::Contentful::Model::Menu.find('asdf')
+
+      # assert
+      expect(main_menu).to be_nil
+    end
+
+    it 'errors fast if ID is wrong content type' do
+      @schema = subject.build_models
+
+      # act
+      expect {
+        _actually_a_menu = WCC::Contentful::Model::Page.find('FNlqULSV0sOy4IoGmyWOW')
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'finds types by content type' do
+      @schema = subject.build_models
+
+      # act
+      menu_items = WCC::Contentful::Model::MenuButton.find_all
+
+      # assert
+      expect(menu_items.count).to eq(11)
+      expect(menu_items.map(&:id).sort).to eq(
+        %w[
+          1EjBdAgOOgAQKAggQoY2as
+          1IJEXB4AKEqQYEm4WuceG2
+          1TikjmGeSIisEWoC4CwokQ
+          2X7Pm2VQmQyAWK0y2wy8me
+          3Jmk4yOwhOY0yKsI6mAQ2a
+          3bZRv5ISCkui6kguIwM2U0
+          4Gye0ybf2EiWCgSyEg0cyE
+          4W3ADPamKsMOg6Gu8aGwOu
+          4tMhra8IAwcEoKS6QSQYcc
+          5NBhDw3i2kUqSwqYok4YQO
+          ZosJIuGfgkky0cA2GsymW
+        ]
+      )
+      menu_item = menu_items.find { |i| i.id == '4tMhra8IAwcEoKS6QSQYcc' }
+      expect(menu_item.custom_button_css).to eq(
+        [
+          'text-decoration: underline;',
+          'color: brown;'
+        ]
+      )
+    end
+
+    it 'finds with filter' do
+      @schema = subject.build_models
+
+      # act
+      menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'custom')
+
+      # assert
+      expect(menu_items.count).to eq(2)
+      expect(menu_items.map(&:id).sort).to eq(
+        %w[3bZRv5ISCkui6kguIwM2U0 4tMhra8IAwcEoKS6QSQYcc]
+      )
+    end
+
+    it 'instruments find_all' do
+      @schema = subject.build_models
+
+      # act
+      expect {
+        WCC::Contentful::Model::MenuButton.find_all(button_style: 'custom')
+      }.to instrument('find_all.model.contentful.wcc')
+    end
+
+    it 'returns empty array if find_all finds nothing' do
+      @schema = subject.build_models
+      store_resp = double
+      expect(store).to receive(:find_all).and_return(store_resp)
+      expect(store_resp).to receive(:apply).and_return(store_resp)
+
+      expect(store_resp).to receive(:to_enum).and_return([])
+
+      # act
+      menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'asdf')
+
+      # assert
+      expect(menu_items.to_a).to eq([])
+    end
+
+    it 'delegates #count to the underlying store w/o iterating the enumerable' do
+      @schema = subject.build_models
+      store_resp = double(count: 1234)
+      expect(store).to receive(:find_all).and_return(store_resp)
+      allow(store_resp).to receive(:apply).and_return(store_resp)
+
+      expect(store_resp).to_not receive(:to_enum)
+
+      # act
+      menu_items = WCC::Contentful::Model::MenuButton.find_all(button_style: 'asdf')
+
+      # assert
+      expect(menu_items.count).to eq(1234)
+    end
+
+    it 'finds single item with filter' do
+      @schema = subject.build_models
+
+      # act
+      redirect = WCC::Contentful::Model::Redirect2.find_by(slug: 'mister_roboto')
+
+      # assert
+      expect(redirect).to_not be_nil
+      expect(redirect.pageReference.title).to eq('Conferences')
+    end
+
+    it 'instruments find_by' do
+      @schema = subject.build_models
+
+      # act
+      expect {
+        WCC::Contentful::Model::Redirect2.find_by(slug: 'mister_roboto')
+      }.to instrument('find_by.model.contentful.wcc')
+    end
+
+    it 'returns nil if find_by finds nothing' do
+      @schema = subject.build_models
+
+      # act
+      redirect = WCC::Contentful::Model::Redirect2.find_by(slug: 'asdf')
+
+      # assert
+      expect(redirect).to be_nil
+    end
+
+    context 'with options' do
+      it 'find_by preloads links when include param > 0' do
+        @schema = subject.build_models
+
+        # act
+        home_page = WCC::Contentful::Model::Homepage.find_by(
+          options: { include: 1 },
+          site_title: 'Watermark Resources'
+        )
+
+        # assert
+        # no on-demand link resolution, it's already been resolved
+        expect(store).to_not receive(:find)
+
+        expect(home_page.heroImage).to be_a(WCC::Contentful::Model::Asset)
+        expect(home_page.heroImage.file.fileName).to eq('worship.jpg')
+
+        expect(home_page.sections[0]).to be_a(WCC::Contentful::Model::SectionFaq)
+        expect(home_page.sections[0].helpText).to eq('asdf')
+      end
+    end
+  end
+
+  describe 'fields' do
+    it 'resolves numeric fields' do
+      @schema = subject.build_models
+
+      # act
+      faq = WCC::Contentful::Model::Faq.find_all.first
+
+      # assert
+      expect(faq.num_faqs).to eq(2)
+      expect(faq.num_faqs_float).to eq(2.1)
+    end
+
+    it 'resolves json blobs' do
+      @schema = subject.build_models
+
+      # act
+      migration = WCC::Contentful::Model::MigrationHistory.find_all.first
+
+      # assert
+      expect(migration.detail).to be_instance_of(Array)
+      expect(migration.detail[0]).to be_instance_of(OpenStruct)
+      expect(migration.detail.dig(0, 'intent', 'intents')).to include(
+        {
+          'meta' => {
+            'callsite' => {
+              'file' =>
+                '/Users/gburgett/projects/wm/jtj-com/db/migrate/20180219160530_test_migration.ts',
+              'line' => 3
+            },
+            'contentTypeInstanceId' => 'contentType/dog/0'
+          },
+          'type' => 'contentType/create',
+          'payload' => {
+            'contentTypeId' => 'dog'
+          }
+        }
+      )
+    end
+
+    # Note: see code comment inside model_builder.rb for why we do not parse DateTime objects
+    it 'does not parse date times' do
+      @schema = subject.build_models
+
+      # act
+      faq = WCC::Contentful::Model::Faq.find('1nzrZZShhWQsMcey28uOUQ')
+
+      # assert
+      expect(faq.date_of_faq).to be_a String
+      expect(faq.date_of_faq).to eq('2018-02-01')
+    end
+
+    it 'resolves coordinates' do
+      @schema = subject.build_models
+
+      # act
+      faq = WCC::Contentful::Model::Faq.find('1nzrZZShhWQsMcey28uOUQ')
+
+      # assert
+      expect(faq.placeOfFaq.lat).to eq(52.5391688192368)
+      expect(faq.placeOfFaq.lon).to eq(13.4033203125)
+    end
+
+    it 'resolves linked types' do
+      @schema = subject.build_models
+
+      # act
+      main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+
+      # assert
+      expect(main_menu.hamburger).to be_instance_of(WCC::Contentful::Model::Menu)
+      expect(main_menu.hamburger.items[0]).to be_instance_of(WCC::Contentful::Model::MenuButton)
+      expect(main_menu.hamburger.items[0].link).to be_instance_of(WCC::Contentful::Model::Page)
+      expect(main_menu.hamburger.items[0].link.title).to eq('About')
+    end
+
+    it 'ignores linked types when they can\'t be resolved' do
+      @schema = subject.build_models
+
+      allow(WCC::Contentful::Model).to receive(:find)
+        .and_call_original
+
+      allow(WCC::Contentful::Model).to receive(:find)
+        .with('5NBhDw3i2kUqSwqYok4YQO', any_args)
+        .and_return(nil)
+
+      # act
+      main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+
+      # assert
+      expect(main_menu.hamburger).to be_instance_of(WCC::Contentful::Model::Menu)
+      expect(main_menu.hamburger.items[1]).to be_instance_of(WCC::Contentful::Model::MenuButton)
+      expect(main_menu.hamburger.items[1].externalLink).to eq('https://www.watermark.org')
+      expect(main_menu.hamburger.items.length).to eq(2)
+    end
+
+    it 'makes ID of linked types accessible' do
+      @schema = subject.build_models
+
+      # act
+      main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+
+      # assert
       expect(store).to_not receive(:find)
+      expect(main_menu.hamburger_id).to eq('6y9DftpiYoA4YiKg2CgoUU')
+    end
 
-      expect(home_page.heroImage).to be_a(WCC::Contentful::Model::Asset)
-      expect(home_page.heroImage.file.fileName).to eq('worship.jpg')
+    it 'makes all IDs of a linked array accessible' do
+      @schema = subject.build_models
 
-      expect(home_page.sections[0]).to be_a(WCC::Contentful::Model::SectionFaq)
-      expect(home_page.sections[0].helpText).to eq('asdf')
+      # act
+      side_menu = WCC::Contentful::Model::Menu.find('6y9DftpiYoA4YiKg2CgoUU')
+
+      # assert
+      expect(store).to_not receive(:find)
+      expect(side_menu.items_ids).to eq(
+        %w[
+          1IJEXB4AKEqQYEm4WuceG2
+          5NBhDw3i2kUqSwqYok4YQO
+          4tMhra8IAwcEoKS6QSQYcc
+        ]
+      )
+    end
+
+    it 'stores backreference on linked type context' do
+      @schema = subject.build_models
+
+      # act
+      main_menu = WCC::Contentful::Model::Menu.find('FNlqULSV0sOy4IoGmyWOW')
+
+      # assert
+      hamburger = main_menu.hamburger
+      expect(hamburger.sys.context.backlinks).to eq([main_menu])
+
+      button = hamburger.items[0]
+      expect(button.sys.context.backlinks).to eq([hamburger, main_menu])
+
+      page = button.link
+      expect(page.sys.context.backlinks).to eq([button, hamburger, main_menu])
+    end
+
+    it 'handles nil linked types' do
+      @schema = subject.build_models
+
+      # act
+      ministries_page = WCC::Contentful::Model::Page.find('JhYhSfZPAOMqsaK8cYOUK')
+
+      # assert
+      expect(ministries_page.sub_menu).to be_nil
+    end
+
+    it 'linked arrays are empty when no links found' do
+      @schema = subject.build_models
+
+      # act
+      privacy_policy_page = WCC::Contentful::Model::Page.find('1tPGouM76soIsM2e0uikgw')
+
+      # assert
+      expect(privacy_policy_page.sections).to eq([])
+    end
+
+    it 'resolves linked assets' do
+      @schema = subject.build_models
+
+      # act
+      homepage = WCC::Contentful::Model::Homepage.find_all.first
+
+      # assert
+      expect(homepage.hero_image).to be_instance_of(WCC::Contentful::Model::Asset)
+      expect(homepage.hero_image.file).to be_a(OpenStruct)
+      expect(homepage.hero_image.title).to eq('worship')
+      expect(homepage.hero_image.file['url']).to eq("//images.contentful.com/#{contentful_space_id}/" \
+        '572YrsdGZGo0sw2Www2Si8/545f53511e362a78a8f34e1837868256/worship.jpg')
+      expect(homepage.hero_image.file['contentType']).to eq('image/jpeg')
+
+      expect(homepage.favicons).to be_a(Array)
+      expect(homepage.favicons.length).to eq(4)
+      expect(homepage.favicons[0]).to be_instance_of(WCC::Contentful::Model::Asset)
+      expect(homepage.favicons[0].file.fileName).to eq('favicon.ico')
+    end
+
+    it 'ignores linked assets when they can\'t be resolved' do
+      @schema = subject.build_models
+
+      allow(WCC::Contentful::Model).to receive(:find)
+        .and_call_original
+
+      allow(WCC::Contentful::Model).to receive(:find)
+        .with('1MsOLBrDwEUAUIuMY8Ys6o', any_args)
+        .and_return(nil)
+
+      # act
+      homepage = WCC::Contentful::Model::Homepage.find_all.first
+
+      # assert
+      expect(homepage.favicons).to be_a(Array)
+      expect(homepage.favicons[1]).to be_instance_of(WCC::Contentful::Model::Asset)
+      expect(homepage.favicons[1].file.fileName).to eq('favicon-32x32.png')
+      expect(homepage.favicons.length).to eq(3)
     end
   end
 

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe WCC::Contentful::ModelBuilder do
       expect(homepage.favicons.length).to eq(3)
     end
 
-    describe 'rich text' do
+    describe 'rich text', focus: true do
       let(:store) { double('store') }
       let(:types) {
         WCC::Contentful::ContentTypeIndexer
@@ -479,7 +479,7 @@ RSpec.describe WCC::Contentful::ModelBuilder do
           block_text = WCC::Contentful::Model::SectionBlockText.find_by(id: '5op6hsU6BYvZCt7S0PjTVv')
 
           # assert
-          expect(block_text.rich_body['content'].length).to eq(9)
+          expect(block_text.rich_body['content'].length).to eq(12)
         end
       end
     end

--- a/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe WCC::Contentful::RichText do
+  let(:fixture) {
+    JSON.parse(load_fixture('contentful/block-text-with-rich-text.json'))
+      .dig('items', 0, 'fields', 'richBody', 'en-US')
+  }
+
+  subject {
+    WCC::Contentful::RichText.tokenize(fixture)
+  }
+
+  it { is_expected.to be_a WCC::Contentful::RichText::Document }
+
+  it 'cannot set node values' do
+    expect {
+      subject.rich_body['content'] = 'test'
+    }.to raise_error(NameError)
+  end
+
+  # RichText structs should be as similar to a Hash as possible.
+  shared_examples 'hash interface' do
+    it 'enumerates keys' do
+      expect(fixture.keys.length).to be > 0
+      expect(subject.keys).to eq(fixture.keys)
+    end
+
+    it 'enumerates with each' do
+      count = 0
+      subject.each do |(key, value)|
+        # values should match what you get when calling the method defined by key
+        expect(value).to eq(subject.public_send(key))
+        count += 1
+      end
+      expect(fixture.length).to be > 0
+      expect(count).to eq(fixture.length)
+
+      # returns an array of tuples when no block provided
+      expect(subject.each.length).to eq(fixture.length)
+    end
+
+    it 'responds to :[] method' do
+      expect(fixture['nodeType']).to be_present
+      expect(subject['nodeType']).to eq(fixture['nodeType'])
+    end
+
+    it 'responds to :dig method' do
+      expect(subject.dig('nodeType')).to eq(fixture['nodeType'])
+    end
+  end
+
+  describe WCC::Contentful::RichText::Document do
+    it_behaves_like 'hash interface'
+  end
+end

--- a/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe WCC::Contentful::RichText do
     it 'responds to :dig method' do
       expect(subject.dig('nodeType')).to eq(fixture['nodeType'])
     end
+
+    it 'as_json is equivalent to input' do
+      hash = subject.as_json
+
+      expect(hash).to eq(fixture)
+    end
   end
 
   describe WCC::Contentful::RichText::Document do

--- a/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe WCC::Contentful::RichText do
 
       # returns an array of tuples when no block provided
       expect(subject.each.length).to eq(fixture.length)
+      expect(subject.each.map(&:first)).to eq(fixture.keys)
     end
 
     it 'responds to :[] method' do

--- a/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
@@ -14,14 +14,6 @@ RSpec.describe WCC::Contentful::RichText do
     described_class.tokenize(fixture)
   }
 
-  it { is_expected.to be_a WCC::Contentful::RichText::Document }
-
-  it 'cannot set node values' do
-    expect {
-      subject.rich_body['content'] = 'test'
-    }.to raise_error(NameError)
-  end
-
   # RichText structs should be as similar to a Hash as possible.
   shared_examples 'WCC::Contentful::RichText::Node' do
     it 'enumerates keys' do
@@ -48,14 +40,28 @@ RSpec.describe WCC::Contentful::RichText do
       expect(subject['nodeType']).to eq(fixture['nodeType'])
     end
 
+    it 'cannot set values' do
+      described_class.members.each do |member|
+        expect {
+          subject[member.to_s] = 'test'
+        }.to raise_error(NameError)
+
+        expect {
+          subject.public_send("#{member}=", 'test')
+        }.to raise_error(NameError)
+      end
+    end
+
     it 'responds to :dig method' do
       expect(subject.dig('nodeType')).to eq(fixture['nodeType'])
     end
   end
 
   describe WCC::Contentful::RichText::Document do
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Document }
     it { is_expected.to have_node_type('document') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
 
     it 'can deep dig' do
       expect(
@@ -69,8 +75,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 2)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Paragraph }
     it { is_expected.to have_node_type('paragraph') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Blockquote do
@@ -78,8 +86,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 3)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Blockquote }
     it { is_expected.to have_node_type('blockquote') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Text do
@@ -87,8 +97,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 4, 'content', 0)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Text }
     it { is_expected.to have_node_type('text') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::EmbeddedEntryInline do
@@ -96,8 +108,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 9, 'content', 1)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::EmbeddedEntryInline }
     it { is_expected.to have_node_type('embedded-entry-inline') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::EmbeddedEntryBlock do
@@ -105,8 +119,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 7)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::EmbeddedEntryBlock }
     it { is_expected.to have_node_type('embedded-entry-block') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::EmbeddedAssetBlock do
@@ -114,8 +130,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 5)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::EmbeddedAssetBlock }
     it { is_expected.to have_node_type('embedded-asset-block') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Heading1 do
@@ -134,8 +152,10 @@ RSpec.describe WCC::Contentful::RichText do
       }
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Heading1 }
     it { is_expected.to have_node_type('heading-1') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Heading2 do
@@ -143,8 +163,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 0)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Heading2 }
     it { is_expected.to have_node_type('heading-2') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Heading3 do
@@ -152,8 +174,10 @@ RSpec.describe WCC::Contentful::RichText do
       document.dig('content', 1)
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Heading3 }
     it { is_expected.to have_node_type('heading-3') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Heading4 do
@@ -172,8 +196,10 @@ RSpec.describe WCC::Contentful::RichText do
       }
     }
 
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to be_a WCC::Contentful::RichText::Heading4 }
     it { is_expected.to have_node_type('heading-4') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 
   describe WCC::Contentful::RichText::Heading5 do
@@ -191,8 +217,11 @@ RSpec.describe WCC::Contentful::RichText do
         ]
       }
     }
-    it_behaves_like 'WCC::Contentful::RichText::Node'
+
+    it { is_expected.to be_a WCC::Contentful::RichText::Heading5 }
     it { is_expected.to have_node_type('heading-5') }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
   end
 end
 

--- a/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/rich_text_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe WCC::Contentful::RichText do
-  let(:fixture) {
+  let(:document) {
     JSON.parse(load_fixture('contentful/block-text-with-rich-text.json'))
       .dig('items', 0, 'fields', 'richBody', 'en-US')
   }
 
+  let(:fixture) {
+    document
+  }
+
   subject {
-    WCC::Contentful::RichText.tokenize(fixture)
+    described_class.tokenize(fixture)
   }
 
   it { is_expected.to be_a WCC::Contentful::RichText::Document }
@@ -19,7 +23,7 @@ RSpec.describe WCC::Contentful::RichText do
   end
 
   # RichText structs should be as similar to a Hash as possible.
-  shared_examples 'hash interface' do
+  shared_examples 'WCC::Contentful::RichText::Node' do
     it 'enumerates keys' do
       expect(fixture.keys.length).to be > 0
       expect(subject.keys).to eq(fixture.keys)
@@ -50,6 +54,151 @@ RSpec.describe WCC::Contentful::RichText do
   end
 
   describe WCC::Contentful::RichText::Document do
-    it_behaves_like 'hash interface'
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('document') }
+
+    it 'can deep dig' do
+      expect(
+        subject.dig('content', 2, 'content', 2, 'data', 'target', 'sys', 'id')
+      ).to eq('1D9ASgqWylh9frKnBv8pSM')
+    end
+  end
+
+  describe WCC::Contentful::RichText::Paragraph do
+    let(:fixture) {
+      document.dig('content', 2)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('paragraph') }
+  end
+
+  describe WCC::Contentful::RichText::Blockquote do
+    let(:fixture) {
+      document.dig('content', 3)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('blockquote') }
+  end
+
+  describe WCC::Contentful::RichText::Text do
+    let(:fixture) {
+      document.dig('content', 4, 'content', 0)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('text') }
+  end
+
+  describe WCC::Contentful::RichText::EmbeddedEntryInline do
+    let(:fixture) {
+      document.dig('content', 9, 'content', 1)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('embedded-entry-inline') }
+  end
+
+  describe WCC::Contentful::RichText::EmbeddedEntryBlock do
+    let(:fixture) {
+      document.dig('content', 7)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('embedded-entry-block') }
+  end
+
+  describe WCC::Contentful::RichText::EmbeddedAssetBlock do
+    let(:fixture) {
+      document.dig('content', 5)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('embedded-asset-block') }
+  end
+
+  describe WCC::Contentful::RichText::Heading1 do
+    let(:fixture) {
+      {
+        'nodeType' => 'heading-1',
+        'data' => {},
+        'content' => [
+          {
+            'nodeType' => 'text',
+            'value' => 'The Meaning Behind Our Name',
+            'marks' => [],
+            'data' => {}
+          }
+        ]
+      }
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('heading-1') }
+  end
+
+  describe WCC::Contentful::RichText::Heading2 do
+    let(:fixture) {
+      document.dig('content', 0)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('heading-2') }
+  end
+
+  describe WCC::Contentful::RichText::Heading3 do
+    let(:fixture) {
+      document.dig('content', 1)
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('heading-3') }
+  end
+
+  describe WCC::Contentful::RichText::Heading4 do
+    let(:fixture) {
+      {
+        'nodeType' => 'heading-4',
+        'data' => {},
+        'content' => [
+          {
+            'nodeType' => 'text',
+            'value' => 'The Meaning Behind Our Name',
+            'marks' => [],
+            'data' => {}
+          }
+        ]
+      }
+    }
+
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('heading-4') }
+  end
+
+  describe WCC::Contentful::RichText::Heading5 do
+    let(:fixture) {
+      {
+        'nodeType' => 'heading-5',
+        'data' => {},
+        'content' => [
+          {
+            'nodeType' => 'text',
+            'value' => 'The Meaning Behind Our Name',
+            'marks' => [],
+            'data' => {}
+          }
+        ]
+      }
+    }
+    it_behaves_like 'WCC::Contentful::RichText::Node'
+    it { is_expected.to have_node_type('heading-5') }
+  end
+end
+
+RSpec::Matchers.define :have_node_type do |expected|
+  match do |actual|
+    actual.node_type == expected &&
+      actual['nodeType'] == expected
   end
 end


### PR DESCRIPTION
This PR builds out an object model for initial RichText support.
The goals for this PR:

* Prevent "unknown field type RichText for field body"
* Allow RichText users to iterate RichText data w/ basic hash methods `[]` and `dig`
* Provide a base Object Model on which we can build more features without introducing breaking changes

refs #260 