### PR TITLE
Sync Engine: Exponential Backoff for Retries

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/configuration.rb
+++ b/wcc-contentful/lib/wcc/contentful/configuration.rb
@@ -3,22 +3,22 @@
 # This object contains all the configuration options for the `wcc-contentful` gem.
 class WCC::Contentful::Configuration
   ATTRIBUTES = %i[
-    space
     access_token
     app_url
-    management_token
-    environment
-    default_locale
-    preview_token
-    webhook_username
-    webhook_password
-    webhook_jobs
     connection
     connection_options
-    update_schema_file
-    schema_file
-    store
+    default_locale
+    environment
     instrumentation_adapter
+    management_token
+    preview_token
+    schema_file
+    space
+    store
+    update_schema_file
+    webhook_jobs
+    webhook_password
+    webhook_username
   ].freeze
 
   # (required) Sets the Contentful Space ID.

--- a/wcc-contentful/lib/wcc/contentful/sync_engine.rb
+++ b/wcc-contentful/lib/wcc/contentful/sync_engine.rb
@@ -186,9 +186,9 @@ module WCC::Contentful
 
         # Enqueues an ActiveJob job to invoke WCC::Contentful.sync! after a given amount
         # of time.
-        def sync_later!(event, wait: 10.seconds)
+        def sync_later!(up_to_id: nil, wait: 10.seconds)
           self.class.set(wait: wait)
-            .perform_later(event)
+            .perform_later(up_to_id: up_to_id)
         end
       end
     end


### PR DESCRIPTION
* Implements an exponential backoff algorithm for the sync engine job, with configurable parameters.

The Contentful CDN aggressively caches content, and it often happens that a Webhook will be sent and processed before the Sync API is able to provide the new content.  This results in a Sync that does not include the entry indicated in the webhook (passed to the job via the `up_to_id` parameter.)  In this case, the following lines appear in the logs, and the job is re-enqueued for 10 minutes later (Changed to 10 seconds in 2bc755a, not yet released)

```
INFO -- : [ActiveJob] [WCC::Contentful::SyncEngine::Job] [8447dd93-0be7-49e9-a7fb-66804f4a3fa4] WCC::Contentful::Event::SyncComplete
INFO -- : [ActiveJob] [WCC::Contentful::SyncEngine::Job] [8447dd93-0be7-49e9-a7fb-66804f4a3fa4] Synced 0 entries.  Next sync token:
  FEnCh...
INFO -- : [ActiveJob] [WCC::Contentful::SyncEngine::Job] [8447dd93-0be7-49e9-a7fb-66804f4a3fa4] Should enqueue again? [true]
```

10 minutes is far too long a time to wait.  This PR more agressively hits the Sync API to try to catch the CDN update as soon as possible.  Now, if the changed entry is not present on the Sync API yet, the SyncEngine::Job will retry after 1 second, then 2 seconds, then 4 seconds, for a total of 4 attempts over 7 seconds before giving up.