### PR TITLE
Fixes deadlocking issue in postgres store

### DIFF
--- a/wcc-contentful/lib/wcc/contentful.rb
+++ b/wcc-contentful/lib/wcc/contentful.rb
@@ -46,9 +46,8 @@ module WCC::Contentful
     end
 
     def logger
-      return Rails.logger if defined?(Rails)
-
-      @logger ||= Logger.new($stderr)
+      ActiveSupport::Deprecation.warn('Use WCC::Contentful::Services.instance.logger instead')
+      WCC::Contentful::Services.instance.logger
     end
   end
 
@@ -90,7 +89,7 @@ module WCC::Contentful
       rescue WCC::Contentful::SimpleClient::ApiError => e
         raise InitializationError, e if configuration.update_schema_file == :always
 
-        WCC::Contentful.logger.warn("Unable to download schema from management API - #{e.message}")
+        Services.instance.logger.warn("Unable to download schema from management API - #{e.message}")
       end
     end
 
@@ -98,7 +97,7 @@ module WCC::Contentful
       begin
         JSON.parse(File.read(configuration.schema_file))['contentTypes'] if File.exist?(configuration.schema_file)
       rescue JSON::ParserError
-        WCC::Contentful.logger.warn("Schema file invalid, ignoring it: #{configuration.schema_file}")
+        Services.instance.warn("Schema file invalid, ignoring it: #{configuration.schema_file}")
         nil
       end
 
@@ -112,7 +111,7 @@ module WCC::Contentful
         content_types = client.content_types(limit: 1000).items if client
       rescue WCC::Contentful::SimpleClient::ApiError => e
         # indicates bad credentials
-        WCC::Contentful.logger.warn("Unable to load content types from API - #{e.message}")
+        Services.instance.logger.warn("Unable to load content types from API - #{e.message}")
       end
     end
 

--- a/wcc-contentful/lib/wcc/contentful/configuration.rb
+++ b/wcc-contentful/lib/wcc/contentful/configuration.rb
@@ -10,6 +10,7 @@ class WCC::Contentful::Configuration
     default_locale
     environment
     instrumentation_adapter
+    logger
     management_token
     preview_token
     schema_file
@@ -181,6 +182,11 @@ class WCC::Contentful::Configuration
   # emit instrumentation events.  The object or module provided here must respond
   # to :instrument like ActiveSupport::Notifications.instrument
   attr_accessor :instrumentation_adapter
+
+  # Sets the logger to be used by the wcc-contentful gem, including stores.
+  # Defaults to the rails logger if in a rails context, otherwise creates a new
+  # logger that writes to STDERR.
+  attr_accessor :logger
 
   def initialize
     @access_token = ENV.fetch('CONTENTFUL_ACCESS_TOKEN', nil)

--- a/wcc-contentful/lib/wcc/contentful/services.rb
+++ b/wcc-contentful/lib/wcc/contentful/services.rb
@@ -132,6 +132,15 @@ module WCC::Contentful
     # Allow it to be injected into a store
     alias_method :_instrumentation, :instrumentation
 
+    # Gets the configured logger, defaulting to Rails.logger in a rails context,
+    # or logging to STDERR in a non-rails context.
+    def logger
+      @logger ||=
+        configuration.logger ||
+        (Rails.logger if defined?(Rails)) ||
+        Logger.new($stderr)
+    end
+
     ##
     # This method enables simple dependency injection -
     # If the target has a setter matching the name of one of the services,

--- a/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/postgres_store.rb
@@ -23,7 +23,8 @@ module WCC::Contentful::Store
       connection_options ||= { dbname: 'postgres' }
       pool_options ||= {}
       @connection_pool = PostgresStore.build_connection_pool(connection_options, pool_options)
-      @dirty = false
+      @dirty = Concurrent::AtomicBoolean.new
+      @mutex = Mutex.new
     end
 
     def set(key, value)
@@ -45,9 +46,12 @@ module WCC::Contentful::Store
           JSON.parse(val) if val
         end
 
-      if views_need_update?(value, previous_value) && !mutex.with_read_lock { @dirty }
-        _instrument 'mark_dirty'
-        mutex.with_write_lock { @dirty = true }
+      if views_need_update?(value, previous_value)
+        # Mark the views as needing to be refreshed, they will be refreshed on the next query.
+        was_dirty = @dirty.make_true
+        # Send out an instrumentation event if we are the thread that marked it dirty
+        # (make_true returns true if the value changed)
+        _instrument 'mark_dirty' if was_dirty
       end
 
       previous_value
@@ -63,17 +67,21 @@ module WCC::Contentful::Store
     end
 
     def delete(key)
-      result = @connection_pool.with { |conn| conn.exec_prepared('delete_by_id', [key]) }
-      return if result.num_tuples == 0
+      _instrument 'delete_by_id', key: key do
+        result = @connection_pool.with { |conn| conn.exec_prepared('delete_by_id', [key]) }
+        return if result.num_tuples == 0
 
-      JSON.parse(result.getvalue(0, 1))
+        JSON.parse(result.getvalue(0, 1))
+      end
     end
 
     def find(key, **_options)
-      result = @connection_pool.with { |conn| conn.exec_prepared('select_entry', [key]) }
-      return if result.num_tuples == 0
+      _instrument 'select_entry', key: key do
+        result = @connection_pool.with { |conn| conn.exec_prepared('select_entry', [key]) }
+        return if result.num_tuples == 0
 
-      JSON.parse(result.getvalue(0, 1))
+        JSON.parse(result.getvalue(0, 1))
+      end
     rescue PG::ConnectionBad
       nil
     end
@@ -87,22 +95,21 @@ module WCC::Contentful::Store
     end
 
     def exec_query(statement, params = [])
-      if mutex.with_read_lock { @dirty }
-        was_dirty =
-          mutex.with_write_lock do
-            was_dirty = @dirty
-            @dirty = false
-            was_dirty
-          end
-
-        if was_dirty
-          _instrument 'refresh_views' do
-            @connection_pool.with { |conn| conn.exec_prepared('refresh_views_concurrently') }
+      if @dirty.true?
+        # Only one thread should call refresh_views_concurrently but all should wait for it to finish.
+        @mutex.synchronize do
+          # We have to check again b/c another thread may have gotten here first
+          if @dirty.true?
+            _instrument 'refresh_views' do
+              @connection_pool.with { |conn| conn.exec_prepared('refresh_views_concurrently') }
+            end
+            # Mark that the views have been refreshed.
+            @dirty.make_false
           end
         end
       end
 
-      logger&.debug("[PostgresStore] #{statement}\n#{params.inspect}")
+      logger&.debug("[PostgresStore] #{statement} #{params.inspect}")
       _instrument 'exec' do
         @connection_pool.with { |conn| conn.exec(statement, params) }
       end

--- a/wcc-contentful/spec/rails_helper.rb
+++ b/wcc-contentful/spec/rails_helper.rb
@@ -48,6 +48,13 @@ if defined?(Rails)
       super
     end
   end)
+
+  RSpec.configure do |c|
+    # skip rspec-rails spec types
+    c.before(:each, rails: false) do
+      skip 'This test is for a non-rails context'
+    end
+  end
 else
   RSpec.configure do |c|
     # skip rspec-rails spec types

--- a/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe WCC::Contentful::Configuration do
     end
   }
 
-  let(:services) { WCC::Contentful::Services.instance }
+  let(:services) { WCC::Contentful::Services.new(config) }
 
   before do
     allow(WCC::Contentful).to receive(:configuration)
       .and_return(config)
+
+    allow(WCC::Contentful::Services).to receive(:instance)
+      .and_return(services)
   end
 
   describe '#store' do
@@ -288,6 +291,38 @@ RSpec.describe WCC::Contentful::Configuration do
 
       # act
       WCC::Contentful::Model.find('test')
+    end
+  end
+
+  describe '#logger' do
+    it 'defaults to rails logger' do
+      config.store :eager_sync, :postgres, ENV.fetch('POSTGRES_CONNECTION', nil)
+
+      # act
+      logger = services.logger
+      store = services.store
+
+      # assert
+      expect(Rails.logger).to be_present
+      expect(logger).to eq(Rails.logger)
+
+      store = middleware_stack(store).find { |s| s.is_a?(WCC::Contentful::Store::PostgresStore) }
+      expect(store.logger).to eq(Rails.logger)
+    end
+
+    it 'injects custom logger into store' do
+      custom_logger = double('custom-logger')
+      config.logger = custom_logger
+      config.store :eager_sync, :postgres, ENV.fetch('POSTGRES_CONNECTION', nil)
+
+      # act
+      logger = services.logger
+      store = services.store
+
+      # assert
+      expect(logger).to eq(custom_logger)
+      store = middleware_stack(store).find { |s| s.is_a?(WCC::Contentful::Store::PostgresStore) }
+      expect(store.logger).to eq(custom_logger)
     end
   end
 

--- a/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/configuration_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe WCC::Contentful::Configuration do
   end
 
   describe '#logger' do
-    it 'defaults to rails logger' do
+    it 'defaults to rails logger in rails context', rails: true do
       config.store :eager_sync, :postgres, ENV.fetch('POSTGRES_CONNECTION', nil)
 
       # act
@@ -308,6 +308,20 @@ RSpec.describe WCC::Contentful::Configuration do
 
       store = middleware_stack(store).find { |s| s.is_a?(WCC::Contentful::Store::PostgresStore) }
       expect(store.logger).to eq(Rails.logger)
+    end
+
+    it 'defaults to new logger in non-rails context', rails: false do
+      config.store :eager_sync, :postgres, ENV.fetch('POSTGRES_CONNECTION', nil)
+
+      # act
+      logger = services.logger
+      store = services.store
+
+      # assert
+      expect(logger).to be_a(Logger)
+
+      store = middleware_stack(store).find { |s| s.is_a?(WCC::Contentful::Store::PostgresStore) }
+      expect(store.logger).to eq(logger)
     end
 
     it 'injects custom logger into store' do

--- a/wcc-contentful/spec/wcc/contentful/sync_engine_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/sync_engine_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe 'WCC::Contentful::SyncEngine::Job', type: :job do
         instrumentation: ActiveSupport::Notifications
       ))
 
+    allow(WCC::Contentful).to receive(:configuration)
+      .and_return(configuration)
+
     described_class.instance_variable_set('@sync_engine', nil)
   end
 


### PR DESCRIPTION
I found that in our Rails apps in Develop, we had frequent deadlocks which were showing up as long times to render views.  I'm still not 100% sure how the deadlocks happened, but I am 100% confident that this new code is still thread safe.

Incidentally I also fixed #264 by injecting a logger from the configuration into the postgres store.