### PR TITLE
Fix autoloading in zeitwerk mode

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/model_api.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_api.rb
@@ -96,7 +96,7 @@ module WCC::Contentful::ModelAPI
       loop do
         begin
           # The app may have defined a model and we haven't loaded it yet
-          const = parent.const_missing(const_name)
+          const = parent.const_get(const_name)
           return const if const && const < self
         rescue NameError => e
           raise e unless e.message =~ /uninitialized constant (.+::)*#{const_name}$/
@@ -156,7 +156,7 @@ module WCC::Contentful::ModelAPI
         const_name = klass.name
         begin
           # the const_name is fully qualified so search from root
-          const = Object.const_missing(const_name)
+          const = Object.const_get(const_name)
           register_for_content_type(content_type, klass: const) if const
         rescue NameError => e
           msg = "Error when reloading constant #{const_name} - #{e}"

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -654,6 +654,8 @@ RSpec.describe WCC::Contentful::ModelAPI do
 
       # assert
       expect(button).to be_a(TestNamespace::BlogPost)
+    ensure
+      TestNamespace.send(:remove_const, 'BlogPost')
     end
 
     it 'falls back to object if not found' do
@@ -671,6 +673,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
         })
 
       blog_post_class = nil
+      allow(Object).to receive(:const_get).and_call_original
       expect(Object).to receive(:const_get).with('BlogPost') do
         blog_post_class =
           Class.new(TestNamespace::Model::BlogPost) do

--- a/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_api_spec.rb
@@ -643,7 +643,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
           }
         })
 
-      expect(TestNamespace).to receive(:const_missing).with('BlogPost') do
+      expect(TestNamespace).to receive(:const_get).with('BlogPost') do
         TestNamespace::BlogPost =
           Class.new(TestNamespace::Model::BlogPost) do
           end
@@ -671,7 +671,7 @@ RSpec.describe WCC::Contentful::ModelAPI do
         })
 
       blog_post_class = nil
-      expect(Object).to receive(:const_missing).with('BlogPost') do
+      expect(Object).to receive(:const_get).with('BlogPost') do
         blog_post_class =
           Class.new(TestNamespace::Model::BlogPost) do
           end


### PR DESCRIPTION
* Switches to use const_get which works in both classic and zeitwerk mode.
* Added doc about a pitfall of Zeitwerk autoloading with app-defined model namespaces

Rails 6 introduced the Zeitwerk autoloader which uses a completely different technique to load application models.  The technique no longer depends on `const_missing` and in fact that method no longer works when a rails application is in `:zeitwerk` mode.

Instead, Zeitwerk depends on [ruby's core "autoload" feature](https://ruby-doc.org/core-2.0.0/Module.html#method-i-autoload).  It sets up the relationship between constants and files beforehand, instead of discovering them on-demand.  The consequence of this is that `const_get` still works to get the constants, but Ruby (not Zeitwerk) auto-loads it on demand from the file.  To the application, the constant exists regardless of whether it has been loaded or not.

More info: https://www.urbanautomaton.com/blog/2020/11/04/rails-autoloading-heaven/
