### PR TITLE
Make rich text tables more consistent with md tables

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/rich_text_renderer.rb
+++ b/wcc-contentful/lib/wcc/contentful/rich_text_renderer.rb
@@ -160,14 +160,21 @@ class WCC::Contentful::RichTextRenderer
 
   def render_table_cell(node)
     content_tag(:td) do
-      render_content(node.content)
+      render_table_cell_content(node.content)
     end
   end
 
   def render_table_header_cell(node)
     content_tag(:th) do
-      render_content(node.content)
+      render_table_cell_content(node.content)
     end
+  end
+
+  def render_table_cell_content(content)
+    # If the content is a single paragraph, render it without the <p> tag
+    return render_content(content.first.content) if content.size == 1 && content.first.node_type == 'paragraph'
+
+    render_content(content)
   end
 
   def render_hyperlink(node)

--- a/wcc-contentful/spec/wcc/contentful/rich_text_renderer_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/rich_text_renderer_spec.rb
@@ -474,35 +474,21 @@ RSpec.describe WCC::Contentful::RichTextRenderer, rails: true do
             <table>
               <thead>
                 <tr>
-                  <th>
-                    <p>Star Wars Movie</p>
-                  </th>
-                  <th>
-                    <p>Rating</p>
-                  </th>
+                  <th>Star Wars Movie</th>
+                  <th>Rating</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td>
-                    <p>Episode 4</p>
-                  </td>
-                  <td>
-                    <p>8</p>
-                  </td>
+                  <td>Episode 4</td>
+                  <td>8</td>
                 </tr>
                 <tr>
-                  <td>
-                    <p>Episode 5</p>
-                  </td>
-                  <td>
-                    <p>10</p>
-                  </td>
+                  <td>Episode 5</td>
+                  <td>10</td>
                 </tr>
                 <tr>
-                  <td>
-                    <p>Episode 6</p>
-                  </td>
+                  <td>Episode 6</td>
                   <td>
                     <p>5</p>
                     <p>


### PR DESCRIPTION
This change makes the table rendering HTML more consistent with the markdown implementation.  Combined with a bit of styling to get around some other issues with the markdown tables, we can get them to render equivalently:

<img width="960" alt="image" src="https://github.com/watermarkchurch/wcc-contentful/assets/430257/502dbd81-219e-40e6-893f-353a17369796">
