### PR TITLE
Markdown Renderer doesn't apply classes to strikethrough

### DIFF
--- a/wcc-contentful-app/lib/wcc/contentful/app/markdown_renderer.rb
+++ b/wcc-contentful-app/lib/wcc/contentful/app/markdown_renderer.rb
@@ -11,6 +11,7 @@ class WCC::Contentful::App::MarkdownRenderer
     @extensions = {
       autolink: true,
       superscript: true,
+      strikethrough: true,
       disable_indented_code_blocks: true,
       tables: true
     }.merge!(options&.delete(:extensions) || {})

--- a/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
+++ b/wcc-contentful-app/spec/helpers/wcc/contentful/app/section_helper_spec.rb
@@ -359,6 +359,22 @@ RSpec.describe WCC::Contentful::App::SectionHelper, type: :helper do
       end
     end
 
+    context 'when content includes marks' do
+      it 'should apply the class to strikethrough marks' do
+        markdown_string =
+          <<-STRING
+            [~~some strikethrough text~~ some normal text](/home){: .text }
+          STRING
+        html_to_render =
+          helper.markdown(markdown_string)
+
+        expect(html_to_render.strip).to eq <<~HTML.strip
+          <div class="formatted-content"><p><a href="/home" class="text"><del>some strikethrough text</del> some normal text</a></p>
+          </div>
+        HTML
+      end
+    end
+
     it 'renders tables with bootstrap .table class' do
       html = helper.markdown(<<~MARKDOWN)
         | col1 | col2 |


### PR DESCRIPTION
When we use our watermark-flavored links with a strikethrough, the class doesn't get applied.  We desired to apply a custom CSS class to a strikethrough element on the uncommon parenting page.

I was able to reproduce the issue in a spec in this PR.