### PR TITLE
Use a to_prepare block inside initializer to make it work with Rails 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,6 @@ workflows:
   build:
     jobs:
       - test:
-          name: test_rails-5.2_ruby-2.7.6
-          ruby: 2.7.6
-          gemfile: gemfiles/rails_5.2_ruby_2.7.6.gemfile
-      - test:
           name: test_rails-6.1_ruby-2.7.6
           ruby: 2.7.6
           gemfile: gemfiles/rails_6.1_ruby_2.7.6.gemfile
@@ -103,8 +99,8 @@ workflows:
 
       - lint: 
           ruby: 2.7.6
-          gemfile: gemfiles/rails_5.2_ruby_2.7.6.gemfile
+          gemfile: gemfiles/rails_6.1_ruby_2.7.6.gemfile
           requires:
-            - test_rails-5.2_ruby-2.7.6
+            - test_rails-6.1_ruby-2.7.6
 
 

--- a/wcc-contentful/lib/wcc/contentful/engine.rb
+++ b/wcc-contentful/lib/wcc/contentful/engine.rb
@@ -2,36 +2,38 @@
 
 module WCC::Contentful
   class Engine < ::Rails::Engine
-    initializer 'enable webhook' do
-      config = WCC::Contentful.configuration
+    initializer 'enable webhook' do |app|
+      app.config.to_prepare do
+        config = WCC::Contentful.configuration
 
-      jobs = []
-      jobs << WCC::Contentful::SyncEngine::Job if WCC::Contentful::Services.instance.sync_engine&.should_sync?
-      jobs.push(*WCC::Contentful.configuration.webhook_jobs)
+        jobs = []
+        jobs << WCC::Contentful::SyncEngine::Job if WCC::Contentful::Services.instance.sync_engine&.should_sync?
+        jobs.push(*WCC::Contentful.configuration.webhook_jobs)
 
-      jobs.each do |job|
-        WCC::Contentful::WebhookController.subscribe(
-          ->(event) do
-            begin
-              if job.respond_to?(:perform_later)
-                job.perform_later(event.to_h)
-              else
-                Rails.logger.error "Misconfigured webhook job: #{job} does not respond to " \
-                                   ':perform_later'
+        jobs.each do |job|
+          WCC::Contentful::WebhookController.subscribe(
+            ->(event) do
+              begin
+                if job.respond_to?(:perform_later)
+                  job.perform_later(event.to_h)
+                else
+                  Rails.logger.error "Misconfigured webhook job: #{job} does not respond to " \
+                                     ':perform_later'
+                end
+              rescue StandardError => e
+                warn "Error in job #{job}: #{e}"
+                Rails.logger.error "Error in job #{job}: #{e}"
               end
-            rescue StandardError => e
-              warn "Error in job #{job}: #{e}"
-              Rails.logger.error "Error in job #{job}: #{e}"
-            end
-          end,
-          with: :call
-        )
+            end,
+            with: :call
+          )
+        end
+
+        next unless config&.management_token.present?
+        next unless config.app_url.present?
+
+        WebhookEnableJob.set(wait: 10.seconds).perform_later if Rails.env.production?
       end
-
-      next unless config&.management_token.present?
-      next unless config.app_url.present?
-
-      WebhookEnableJob.set(wait: 10.seconds).perform_later if Rails.env.production?
     end
 
     config.generators do |g|


### PR DESCRIPTION
This PR updates the gem to use a `to_prepare` block inside the `initializer` block to make it compatible with Rails 7.0.

The previous code was working with Rails 6.1 but it didn't with Rails 7.0. The new code should be compatible with both Rails versions.