### PR TITLE
Ruby 3 webhook bug

### DIFF
--- a/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
+++ b/wcc-contentful/app/jobs/wcc/contentful/webhook_enable_job.rb
@@ -13,7 +13,7 @@ module WCC::Contentful
       client = WCC::Contentful::SimpleClient::Management.new(
         **args
       )
-      enable_webhook(client, args.slice(:receive_url, :webhook_username, :webhook_password))
+      enable_webhook(client, **args.slice(:receive_url, :webhook_username, :webhook_password))
     end
 
     def enable_webhook(client, receive_url:, webhook_username: nil, webhook_password: nil)

--- a/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
+++ b/wcc-contentful/spec/jobs/wcc/contentful/webhook_enable_job_spec.rb
@@ -133,8 +133,11 @@ RSpec.describe 'WCC::Contentful::WebhookEnableJob', type: :job do
 
     it 'invokes #post_webhook_definition with args' do
       body = nil
+      allow_any_instance_of(WCC::Contentful::SimpleClient::Management)
+        .to receive(:webhook_definitions)
+        .and_return(double(items: []))
       expect_any_instance_of(WCC::Contentful::SimpleClient::Management)
-        .to receive(:post_webhook_definition) do |b|
+        .to receive(:post_webhook_definition) do |_instance, b|
           body = b
           double(raw: {})
         end


### PR DESCRIPTION
Fixes the following bug occurring in reengage.com with ruby 3:
> wrong number of arguments (given 2, expected 1; required keyword: receive_url)

https://app.bugsnag.com/watermark-community-church/reengage/errors/6543a34ae2622d0008f1861a