### PR TITLE
Add support for tags

### DIFF
--- a/wcc-contentful/lib/wcc/contentful/link.rb
+++ b/wcc-contentful/lib/wcc/contentful/link.rb
@@ -5,21 +5,30 @@ class WCC::Contentful::Link
 
   LINK_TYPES = {
     Asset: 'Asset',
-    Link: 'Entry'
+    Link: 'Entry',
+    Tag: 'Tag'
   }.freeze
 
   def initialize(model, link_type = nil)
-    @id = model.try(:id) || model
-    @link_type = link_type
-    @link_type ||= model.is_a?(WCC::Contentful::Model::Asset) ? :Asset : :Link
-    @raw =
-      {
-        'sys' => {
-          'type' => 'Link',
-          'linkType' => LINK_TYPES[@link_type] || link_type,
-          'id' => @id
+    if model.is_a?(Hash)
+      raise ArgumentError, 'Not a Link' unless model.dig('sys', 'type') == 'Link'
+
+      @raw = model
+      @id = model.dig('sys', 'id')
+      @link_type = model.dig('sys', 'linkType')
+    else
+      @id = model.try(:id) || model
+      @link_type = link_type
+      @link_type ||= model.is_a?(WCC::Contentful::Model::Asset) ? :Asset : :Link
+      @raw =
+        {
+          'sys' => {
+            'type' => 'Link',
+            'linkType' => LINK_TYPES[@link_type] || link_type,
+            'id' => @id
+          }
         }
-      }
+    end
   end
 
   alias_method :to_h, :raw

--- a/wcc-contentful/lib/wcc/contentful/metadata.rb
+++ b/wcc-contentful/lib/wcc/contentful/metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+WCC::Contentful::Metadata =
+  Struct.new(:raw) do
+    def tags
+      @tags ||=
+        Array(raw['tags']).map do |tag|
+          WCC::Contentful::Link.new(tag) if tag.is_a?(Hash)
+        end
+    end
+  end

--- a/wcc-contentful/lib/wcc/contentful/model_builder.rb
+++ b/wcc-contentful/lib/wcc/contentful/model_builder.rb
@@ -3,6 +3,7 @@
 require 'ostruct'
 require_relative './link'
 require_relative './sys'
+require_relative './metadata'
 require_relative './rich_text'
 
 module WCC::Contentful
@@ -87,6 +88,10 @@ module WCC::Contentful
               OpenStruct.new(context).freeze
             )
 
+            @metadata = WCC::Contentful::Metadata.new(
+              raw['metadata']
+            )
+
             typedef.fields.each_value do |f|
               raw_value = raw.dig('fields', f.name)
 
@@ -120,6 +125,7 @@ module WCC::Contentful
           end
 
           attr_reader :sys
+          attr_reader :metadata
           attr_reader :raw
 
           delegate :id, to: :sys

--- a/wcc-contentful/lib/wcc/contentful/simple_client.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client.rb
@@ -26,7 +26,7 @@ module WCC::Contentful
   class SimpleClient
     include WCC::Contentful::Instrumentation
 
-    attr_reader :api_url, :space
+    attr_reader :api_url, :space, :environment
 
     # Creates a new SimpleClient with the given configuration.
     #
@@ -54,9 +54,10 @@ module WCC::Contentful
       # https://www.contentful.com/developers/docs/references/content-preview-api/#/introduction/api-rate-limits
       @rate_limit_wait_timeout = @options[:rate_limit_wait_timeout] || 1.5
 
-      return unless options[:environment].present?
+      @environment = options[:environment]
+      return unless @environment.present?
 
-      @api_url = URI.join(@api_url, 'environments/', "#{options[:environment]}/")
+      @api_url = URI.join(@api_url, 'environments/', "#{@environment}/")
     end
 
     # performs an HTTP GET request to the specified path within the configured

--- a/wcc-contentful/lib/wcc/contentful/simple_client/cdn.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/cdn.rb
@@ -74,22 +74,23 @@ class WCC::Contentful::SimpleClient::Cdn < WCC::Contentful::SimpleClient
     resp.assert_ok!
   end
 
-# Retrieves a single tag by ID
-# 
-# @param id [String] The ID of the tag to retrieve
-# @param query [Hash] Optional query parameters
-# @return [Response] Response containing the tag
-# @raise [ArgumentError] If id is nil or empty
-# @example
-#   client.tag('sports')
-def tag(id, query = {})
-  raise ArgumentError, 'id cannot be nil or empty' if id.nil? || id.empty?
-  resp =
-    _instrument 'tags', id: id, query: query do
-      get("tags/#{id}", query)
-    end
-  resp.assert_ok!
-end
+  # Retrieves a single tag by ID
+  #
+  # @param id [String] The ID of the tag to retrieve
+  # @param query [Hash] Optional query parameters
+  # @return [Response] Response containing the tag
+  # @raise [ArgumentError] If id is nil or empty
+  # @example
+  #   client.tag('sports')
+  def tag(id, query = {})
+    raise ArgumentError, 'id cannot be nil or empty' if id.nil? || id.empty?
+
+    resp =
+      _instrument 'tags', id: id, query: query do
+        get("tags/#{id}", query)
+      end
+    resp.assert_ok!
+  end
 
   # Accesses the Sync API to get a list of items that have changed since
   # the last sync.  Accepts a block that receives each changed item, and returns

--- a/wcc-contentful/lib/wcc/contentful/simple_client/cdn.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/cdn.rb
@@ -74,13 +74,22 @@ class WCC::Contentful::SimpleClient::Cdn < WCC::Contentful::SimpleClient
     resp.assert_ok!
   end
 
-  def tag(id, query = {})
-    resp =
-      _instrument 'tags', id: id, query: query do
-        get("tags/#{id}", query)
-      end
-    resp.assert_ok!
-  end
+# Retrieves a single tag by ID
+# 
+# @param id [String] The ID of the tag to retrieve
+# @param query [Hash] Optional query parameters
+# @return [Response] Response containing the tag
+# @raise [ArgumentError] If id is nil or empty
+# @example
+#   client.tag('sports')
+def tag(id, query = {})
+  raise ArgumentError, 'id cannot be nil or empty' if id.nil? || id.empty?
+  resp =
+    _instrument 'tags', id: id, query: query do
+      get("tags/#{id}", query)
+    end
+  resp.assert_ok!
+end
 
   # Accesses the Sync API to get a list of items that have changed since
   # the last sync.  Accepts a block that receives each changed item, and returns

--- a/wcc-contentful/lib/wcc/contentful/simple_client/cdn.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/cdn.rb
@@ -65,6 +65,23 @@ class WCC::Contentful::SimpleClient::Cdn < WCC::Contentful::SimpleClient
     resp.assert_ok!
   end
 
+  # https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/tags/tag-collection/get-all-tags/console
+  def tags(query = {})
+    resp =
+      _instrument 'tags', query: query do
+        get('tags', query)
+      end
+    resp.assert_ok!
+  end
+
+  def tag(id, query = {})
+    resp =
+      _instrument 'tags', id: id, query: query do
+        get("tags/#{id}", query)
+      end
+    resp.assert_ok!
+  end
+
   # Accesses the Sync API to get a list of items that have changed since
   # the last sync.  Accepts a block that receives each changed item, and returns
   # the next sync token.

--- a/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/management.rb
@@ -66,6 +66,34 @@ class WCC::Contentful::SimpleClient::Management < WCC::Contentful::SimpleClient
     resp.assert_ok!
   end
 
+  def tags(query = {})
+    resp =
+      _instrument 'tags', query: query do
+        get("/spaces/#{space}/environments/#{environment}/tags", query)
+      end
+    resp.assert_ok!
+  end
+
+  def tag(key, query = {})
+    resp =
+      _instrument 'tags', tag: key, query: query do
+        get("/spaces/#{space}/environments/#{environment}/tags/#{key}", query)
+      end
+    resp.assert_ok!
+  end
+
+  def tag_create(tag_definition)
+    unless tag_id = tag_definition.dig('sys', 'id')
+      raise ArgumentError, "Missing tag ID in #{tag_definition}"
+    end
+
+    resp =
+      _instrument 'tag_create' do
+        post("/spaces/#{space}/environments/#{environment}/tags/#{tag_id}", tag_definition)
+      end
+    resp.assert_ok!
+  end
+
   # {
   #   "name": "My webhook",
   #   "url": "https://www.example.com/test",

--- a/wcc-contentful/lib/wcc/contentful/simple_client/typhoeus_adapter.rb
+++ b/wcc-contentful/lib/wcc/contentful/simple_client/typhoeus_adapter.rb
@@ -29,6 +29,18 @@ class WCC::Contentful::SimpleClient::TyphoeusAdapter
     )
   end
 
+  def put(url, body, headers = {}, proxy = {})
+    raise NotImplementedError, 'Proxying Not Yet Implemented' if proxy[:host]
+
+    Response.new(
+      Typhoeus.put(
+        url,
+        body: body.to_json,
+        headers: headers
+      )
+    )
+  end
+
   class Response < SimpleDelegator
     delegate :to_s, to: :body
 

--- a/wcc-contentful/lib/wcc/contentful/store/rspec_examples/basic_store.rb
+++ b/wcc-contentful/lib/wcc/contentful/store/rspec_examples/basic_store.rb
@@ -224,6 +224,94 @@ RSpec.shared_examples 'basic store' do
       found2 = subject.find('1qLdW7i7g4Ycq6i4Cckg44')
       expect(found2.dig('fields', 'slug', 'en-US')).to eq('redirect-with-slug-and-url')
     end
+
+    it 'stores metadata including tags', focus: true do
+      entry_with_tags = JSON.parse <<~JSON
+        {
+          "metadata": {
+            "tags": [
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Tag",
+                  "id": "ministry_careers-in-motion"
+                }
+              }
+            ],
+            "concepts": []
+          },
+          "sys": {
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "hw5pse7y1ojx"
+              }
+            },
+            "id": "1h5ce0SYZq8cELhESiJFkA",
+            "type": "Entry",
+            "createdAt": "2020-02-06T20:25:19.188Z",
+            "updatedAt": "2024-11-21T19:02:37.381Z",
+            "environment": {
+              "sys": {
+                "id": "dev",
+                "type": "Link",
+                "linkType": "Environment"
+              }
+            },
+            "publishedVersion": 73,
+            "revision": 7,
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "page"
+              }
+            }
+          },
+          "fields": {
+            "title": {
+              "en-US": "Finances and Career Care"
+            },
+            "slug": {
+              "en-US": "/ministries/financialcareers"
+            },
+            "sections": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "4agnOGg0LQZrCbF4OeMEbj"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "614GfdpLaD5gjc0U3sITXY"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "xM5NWKiZSRUoUxXvoiYW4"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      JSON
+
+      # act
+      subject.set('1h5ce0SYZq8cELhESiJFkA', entry_with_tags)
+      found = subject.find('1h5ce0SYZq8cELhESiJFkA')
+
+      # assert
+      expect(found.dig('metadata', 'tags', 0, 'sys', 'id')).to eq('ministry_careers-in-motion')
+    end
   end
 
   describe '#delete' do

--- a/wcc-contentful/spec/fixtures/contentful/simple_client/single-tag.json
+++ b/wcc-contentful/spec/fixtures/contentful/simple_client/single-tag.json
@@ -1,0 +1,39 @@
+{
+  "sys": {
+    "type": "Tag",
+    "id": "ministry-external-focus",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "hw5pse7y1ojx"
+      }
+    },
+    "environment": {
+      "sys": {
+        "id": "dev",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "0SUbYs2vZlXjVR6bH6o83O"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "0SUbYs2vZlXjVR6bH6o83O"
+      }
+    },
+    "createdAt": "2024-11-20T15:07:07.311Z",
+    "updatedAt": "2024-11-20T15:07:07.311Z",
+    "version": 1,
+    "visibility": "private"
+  },
+  "name": "Ministry: External Focus"
+}

--- a/wcc-contentful/spec/fixtures/contentful/simple_client/tag_create.json
+++ b/wcc-contentful/spec/fixtures/contentful/simple_client/tag_create.json
@@ -1,0 +1,39 @@
+{
+  "name": "Ministry: Weddings at Watermark",
+  "sys": {
+    "visibility": "public",
+    "type": "Tag",
+    "id": "ministry_weddings",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "hw5pse7y1ojx"
+      }
+    },
+    "environment": {
+      "sys": {
+        "id": "dev",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "version": 1,
+    "createdAt": "2024-11-20T21:11:23.571Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "0SUbYs2vZlXjVR6bH6o83O"
+      }
+    },
+    "updatedAt": "2024-11-20T21:11:23.571Z",
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "0SUbYs2vZlXjVR6bH6o83O"
+      }
+    }
+  }
+}

--- a/wcc-contentful/spec/fixtures/contentful/simple_client/tags.json
+++ b/wcc-contentful/spec/fixtures/contentful/simple_client/tags.json
@@ -1,0 +1,36 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "name": "NY Campaign",
+      "sys": {
+        "visibility": "public",
+        "type": "Tag",
+        "id": "nyCampaign",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "yadj1kx9rmg0"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "staging"
+          }
+        },
+        "version": 1,
+        "createdAt": "2016-12-20T10:43:35.772Z",
+        "updatedAt": "2016-12-20T10:43:35.772Z",
+        "revision": 1
+      }
+    }
+  ]
+}

--- a/wcc-contentful/spec/wcc/contentful/entry_locale_transformer_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/entry_locale_transformer_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe WCC::Contentful::EntryLocaleTransformer do
   let(:entry) do
     JSON.parse(<<~JSON)
       {
+        "metadata": {
+          "tags": [
+            {
+              "sys": {
+                "type": "Link",
+                "linkType": "Tag",
+                "id": "ministry_careers-in-motion"
+              }
+            }
+          ],
+          "concepts": []
+        },
         "sys": {
           "space": {
             "sys": {
@@ -152,6 +164,14 @@ RSpec.describe WCC::Contentful::EntryLocaleTransformer do
       # assert
       expect(localized_entry.dig('sys', 'locale')).to eq('es-US')
       expect(localized_entry.key?('fields')).to be false
+    end
+
+    it 'preserves metadata' do
+      localized_entry = subject.transform_to_locale(entry, 'es-US')
+
+      expect(localized_entry.dig('metadata', 'tags', 0, 'sys', 'id')).to eq(
+        'ministry_careers-in-motion'
+      )
     end
   end
 

--- a/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/model_builder_spec.rb
@@ -818,6 +818,54 @@ RSpec.describe WCC::Contentful::ModelBuilder do
     end
   end
 
+  describe 'metadata' do
+    let(:entry_with_tags) {
+      JSON.parse <<~JSON
+        {
+          "fields": {
+            "title": "Hello, World!"
+          },
+          "metadata": {
+            "tags": [
+              {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Tag",
+                  "id": "ministry-regeneration"
+                }
+              }
+            ]
+          },
+          "sys": {
+            "id": "5KsDBWseXY6QegucYAoacS",
+            "type": "Entry",
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "page"
+              }
+            },
+            "createdAt": "2016-12-20T10:43:35.772Z",
+            "updatedAt": "2016-12-20T10:43:35.772Z",
+            "revision": 1,
+            "locale": "en-US"
+          }
+        }
+      JSON
+    }
+
+    it 'parses tags' do
+      @schema = subject.build_models
+
+      entry = WCC::Contentful::Model.new_from_raw(entry_with_tags)
+
+      expect(entry.metadata).to be_a(WCC::Contentful::Metadata)
+      expect(entry.metadata.tags.first).to be_a(WCC::Contentful::Link)
+      expect(entry.metadata.tags.first.id).to eq('ministry-regeneration')
+    end
+  end
+
   def with_tempfile(name, contents)
     file = Tempfile.open(name)
     begin

--- a/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
@@ -269,12 +269,12 @@ RSpec.describe WCC::Contentful::SimpleClient::Management do
         end
 
         it 'gets single tag' do
-          stub_request(:get, 'https://api.contentful.com/spaces/testspace/environments/testenv/tags/nyCampaign')
+          stub_request(:get, 'https://api.contentful.com/spaces/testspace/environments/testenv/tags/ministry-external-focus')
             .with(headers: { Authorization: 'Bearer testtoken' })
             .to_return(body: load_fixture('contentful/simple_client/single-tag.json'))
 
           # act
-          resp = client.tag('nyCampaign')
+          resp = client.tag('ministry-external-focus')
 
           # assert
           resp.assert_ok!

--- a/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
+++ b/wcc-contentful/spec/wcc/contentful/simple_client/management_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe WCC::Contentful::SimpleClient::Management do
             }
           JSON
 
-          stub_request(:post, 'https://api.contentful.com/spaces/testspace/environments/testenv/tags/ministry_weddings')
+          stub_request(:put, 'https://api.contentful.com/spaces/testspace/environments/testenv/tags/ministry_weddings')
             .with(headers: {
               Authorization: 'Bearer testtoken',
               'Content-Type' => 'application/vnd.contentful.management.v1+json'


### PR DESCRIPTION
This PR adds the ability to get tags from the "metadata" of an entry.  It also adds support for querying and updating tags via the content delivery and management APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced tag management functionality, including methods to retrieve and create tags.
	- Enhanced metadata handling in the content model, allowing for better tag processing.
	- Added support for multiple environments in the client configuration.
	- New methods for querying all tags and retrieving specific tags by ID.

- **Bug Fixes**
	- Improved validation logic for link types in the initialization process.

- **Tests**
	- Expanded test coverage for tag-related functionalities and metadata handling, including tests for tag retrieval, creation, and preservation during transformations.

- **Documentation**
	- New JSON fixtures added for testing tag structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->